### PR TITLE
Fix action version in build-tag workflow

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -96,7 +96,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine-amd64 \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-debian-arm64
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@69e5d0b # v2.0.0
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
         continue-on-error: true
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem

The `build-tag` workflow was failing at the `create-manifests` step due to an invalid action reference:

```
##[error]Unable to resolve action `softprops/action-gh-release@69e5d0b`, unable to find version `69e5d0b`
```

## Solution

Updated `softprops/action-gh-release` from broken reference `@69e5d0b` to latest version `v2.4.1` (`@6da8fa9354ddfdc4aeace5fc48d7f679b5214090`).

## Testing

This fix will allow the `build-tag` workflow to complete successfully and create GitHub releases when tags are pushed.