### PR TITLE
Revert to root user execution for GitHub Actions compatibility

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,21 +37,10 @@ RUN apk add --no-cache \
   git \
   openssh \
   npm \
-  wget \
-  sudo
+  wget
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
 RUN npm install /npm
-
-# Add texuser for dedicated LaTeX environment use
-RUN addgroup -g 2000 texuser && \
-    adduser -D -u 2000 -G texuser texuser && \
-    chown -R texuser:texuser /npm && \
-    chown -R texuser:texuser /workdir && \
-    echo "texuser ALL=(ALL) NOPASSWD: /bin/chown, /bin/chmod" > /etc/sudoers.d/texuser && \
-    chmod 0440 /etc/sudoers.d/texuser
-
-USER texuser
 WORKDIR /workdir
 CMD ["bash"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -37,22 +37,10 @@ RUN apt-get update \
   wget \
   git \
   ssh \
-  sudo \
   && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
 RUN npm install /npm
-
-# Add texuser for dedicated LaTeX environment use
-# Use UID 2000 for future-proof isolation from system users
-RUN groupadd -g 2000 texuser && \
-    useradd -u 2000 -g texuser -m -s /bin/bash texuser && \
-    chown -R texuser:texuser /npm && \
-    chown -R texuser:texuser /workdir && \
-    echo "texuser ALL=(ALL) NOPASSWD: /bin/chown, /bin/chmod" > /etc/sudoers.d/texuser && \
-    chmod 0440 /etc/sudoers.d/texuser
-
-USER texuser
 WORKDIR /workdir
 CMD ["bash"]


### PR DESCRIPTION
## Summary

このPRは、GitHub Actions container job での権限エラーを解決するため、Docker image を root ユーザー実行に戻します。

## Changes

- Alpine と Debian の両 Dockerfile から `USER texuser/node` ディレクティブを削除
- `sudo` パッケージと関連設定を削除
- 2025b の動作（root 実行）に戻しつつ、機能改善（textlint-rule-terminology など）は保持

## Problem Context

2025c-2025f で non-root ユーザー実行を試みましたが、GitHub Actions で以下のエラーが発生：

```
Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/...'
```

根本原因は、GitHub Actions ランナーが動的に作成する `_runner_file_commands/` ディレクトリに対して、container 内の non-root ユーザーが書き込み権限を持たないことです。

## Solution Rationale

root 実行は以下の理由で適切です：

1. **CI/CD 環境**: GitHub Actions の隔離されたコンテナで一時的に実行
2. **教育用途**: 学生の LaTeX 環境として使用され、機密情報は扱わない
3. **シンプルさ**: texlive 公式 Docker image も root で実行
4. **実績**: 2025b まで問題なく動作していた

## Testing

- [ ] Alpine image のビルド確認
- [ ] Debian image のビルド確認
- [ ] GitHub Actions での動作確認（sotsuron-report-template PR #13）

## Release Plan

このPRをマージ後：
1. 2025g としてタグ付け・リリース
2. Docker image をビルド・push
3. latex-release-action から permission fix を削除（v2.5.0）
4. 各テンプレートを 2025g に更新