### PR TITLE
Remove alpine-texlive-ja-textlint repository name tags

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -21,7 +21,6 @@ jobs:
           context: ./alpine/
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/alpine-texlive-ja-textlint:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine-amd64
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:alpine-amd64
@@ -103,7 +102,6 @@ jobs:
           # Update alpine tags (version-less)
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:alpine \
-            -t ghcr.io/${{ github.repository_owner }}/alpine-texlive-ja-textlint:latest \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-alpine-amd64
       - name: Update debian tag
         run: |


### PR DESCRIPTION
## Changes

Removed `alpine-texlive-ja-textlint` repository name tags to simplify GitHub Packages page:

- ❌ Removed `alpine-texlive-ja-textlint:${version}` tag
- ❌ Removed `alpine-texlive-ja-textlint:latest` tag

## Benefits

- Reduces visible tag count by 2
- Simplifies GitHub Packages page presentation
- Does not affect any recommended usage patterns
- All main tags (`latest`, version tags, `alpine`, `debian`) remain unchanged

## Tag Strategy After This Change

**User-facing tags (recommended):**
- `2025i` - Main version tag
- `latest` - Latest version
- `alpine` - Alpine latest
- `debian` - Debian latest
- `2025i-alpine` - Specific version Alpine
- `2025i-debian` - Specific version Debian

**Internal tags (for multi-arch manifest):**
- `2025i-alpine-amd64`
- `2025i-debian-amd64`
- `2025i-debian-arm64`
- (architecture-specific tags)

## Related Issue

Refs #31