### PR TITLE
Configure Renovate bot for independent dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,29 +2,34 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "dependencyDashboardLabels": ["dependencies"],
-  "extends": ["workarounds:all"],
+  "extends": ["config:base", "workarounds:all"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["after 9pm on sunday"],
+  "semanticCommits": "enabled",
   "packageRules": [
     {
-      "automerge": true,
-      "labels": ["dependencies"],
-      "matchPackagePatterns": ["*"],
-      "rangeStrategy": "bump",
-      "reviewers": ["3846masa"],
-      "schedule": ["after 8:00 pm"],
-      "semanticCommitType": "chore",
-      "semanticCommits": "enabled"
-    },
-    {
-      "automerge": true,
+      "description": "GitHub Actions version updates",
       "matchManagers": ["github-actions"],
-      "pinDigests": true
+      "automerge": false,
+      "pinDigests": true,
+      "labels": ["dependencies", "github-actions"],
+      "semanticCommitType": "ci"
     },
     {
-      "automerge": true,
+      "description": "Docker base image updates",
       "matchManagers": ["dockerfile"],
-      "pinDigests": true
+      "automerge": false,
+      "pinDigests": true,
+      "labels": ["dependencies", "docker"],
+      "semanticCommitType": "build"
+    },
+    {
+      "description": "npm dependency updates",
+      "matchManagers": ["npm"],
+      "automerge": false,
+      "labels": ["dependencies", "npm"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "chore"
     }
-  ],
-  "printConfig": true,
-  "timezone": "Asia/Tokyo"
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,6 @@
     {
       "description": "GitHub Actions version updates",
       "matchManagers": ["github-actions"],
-      "automerge": false,
       "pinDigests": true,
       "labels": ["dependencies", "github-actions"],
       "semanticCommitType": "ci"
@@ -18,7 +17,6 @@
     {
       "description": "Docker base image updates",
       "matchManagers": ["dockerfile"],
-      "automerge": false,
       "pinDigests": true,
       "labels": ["dependencies", "docker"],
       "semanticCommitType": "build"
@@ -26,7 +24,6 @@
     {
       "description": "npm dependency updates",
       "matchManagers": ["npm"],
-      "automerge": false,
       "labels": ["dependencies", "npm"],
       "rangeStrategy": "bump",
       "semanticCommitType": "chore"


### PR DESCRIPTION
## Summary
- upstream (Paperist/texlive-ja) からコピーされたままの Renovate 設定を fork 向けにカスタマイズ
- upstream との差分の大半が Renovate による依存関係更新だったため、fork 独自に Renovate を運用することで upstream 追随を不要にする

## Changes
- upstream の reviewer (`3846masa`) を削除
- automerge を無効化（手動レビュー必須）
- 更新頻度を毎日 → **週1回（日曜 21:00 JST）** に変更
- カテゴリ別ラベル付け（`github-actions`, `docker`, `npm`）
- semantic commit type をカテゴリ別に分類（`ci`, `build`, `chore`）

## Next steps
PR マージ後、Renovate GitHub App の有効化が必要:
1. https://github.com/apps/renovate → Configure
2. smkwlab organization で `texlive-ja-textlint` リポジトリを追加