### PR TITLE
Migrate Renovate preset from config:base to config:recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "dependencyDashboardLabels": ["dependencies"],
-  "extends": ["config:base", "workarounds:all"],
+  "extends": ["config:recommended", "workarounds:all"],
   "timezone": "Asia/Tokyo",
   "schedule": ["after 9pm on sunday"],
   "semanticCommits": "enabled",


### PR DESCRIPTION
## Summary
Renovate Dependency Dashboard が「Config Migration Needed」として `config:base` の廃止を通知していたため、新しい `config:recommended` に移行します。

## Change
```diff
-  "extends": ["config:base", "workarounds:all"],
+  "extends": ["config:recommended", "workarounds:all"],
```

## Reference
- [Renovate docs: config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended)