### PR TITLE
Use shared Renovate preset from smkwlab/.github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,32 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "dependencyDashboardLabels": ["dependencies"],
-  "extends": ["config:recommended", "workarounds:all"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["after 9pm on sunday"],
-  "semanticCommits": "enabled",
-  "packageRules": [
-    {
-      "description": "GitHub Actions version updates",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true,
-      "labels": ["dependencies", "github-actions"],
-      "semanticCommitType": "ci"
-    },
-    {
-      "description": "Docker base image updates",
-      "matchManagers": ["dockerfile"],
-      "pinDigests": true,
-      "labels": ["dependencies", "docker"],
-      "semanticCommitType": "build"
-    },
-    {
-      "description": "npm dependency updates",
-      "matchManagers": ["npm"],
-      "labels": ["dependencies", "npm"],
-      "rangeStrategy": "bump",
-      "semanticCommitType": "chore"
-    }
-  ]
+  "extends": ["github>smkwlab/.github:latex#v1"]
 }


### PR DESCRIPTION
## Summary

Replace the duplicated Renovate configuration with a one-line `extends` of the org-wide shared preset, pinned to the `v1` tag.

```jsonc
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:latex#v1"]
}
```

The previous config (github-actions/docker `pinDigests`, npm `bump`, weekly Sunday schedule, `workarounds:all`) is now defined centrally in `smkwlab/.github` (`default.json` + `latex.json` @ `v1`), so behavior is preserved. Patch/digest auto-merge is now applied per the shared org policy.

## Context

Part of the ecosystem-wide Renovate consolidation. Shared presets added/pinned in smkwlab/.github#28 and #29 (both merged, released as `v1.6.0`).
