### PR TITLE
Update Node.js runtime from 20 to 24 (LTS)

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -27,7 +27,7 @@ RUN tlmgr install \
   lm \
   latexmk
 
-FROM node:20-trixie-slim@sha256:d0b7814dbe06843af4a89b578a19945994d7fa81e0100347ef24c9690cf10ed4
+FROM node:24-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c
 ENV PATH /usr/local/bin/texlive:/npm/node_modules/.bin:$PATH
 WORKDIR /workdir
 COPY --from=installer /usr/local/texlive /usr/local/texlive


### PR DESCRIPTION
## 背景

Debian イメージのランタイムに使われている **Node.js 20「Iron」は 2026年4月末で EOL(サポート終了)** となり、セキュリティアップデートが提供されなくなりました。現在(2026年6月)は既にサポート切れのため、現行アクティブ LTS の **Node.js 24「Krypton」** へ更新します。

## 変更内容

- \`debian/Dockerfile\`: ランタイムステージのベースを更新
  - \`node:20-trixie-slim\` → \`node:24-trixie-slim\`
  - digest も最新の index digest に更新(amd64 / arm64 両対応を確認済み)

## 動作確認

\`node:24-trixie-slim\`(\`24.16.0\`)上で本リポジトリの \`package.json\` / \`package-lock.json\` を用いて検証:

- ✅ \`npm ci\` 成功
- ✅ \`textlint --version\` → v14.8.4 正常動作
- ✅ マルチアーキ index digest(linux/amd64, linux/arm64)であることを確認

\`package.json\` には \`engines\` 指定がなく、依存は textlint 系のみのため影響は限定的です。

## 補足

Alpine(\`3.22.2\`→\`3.22.4\`/\`3.23\`)および Debian installer(\`13.1\`→\`13.5\`)の追従更新も別途検討の余地がありますが、本 PR は EOL 対応として優先度の高い Node.js 更新に絞っています。