### PR TITLE
Set container timezone to JST (Asia/Tokyo)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -40,8 +40,8 @@ RUN apk add --no-cache \
   npm \
   tzdata \
   wget \
-  && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
-  && echo "Asia/Tokyo" > /etc/timezone
+  && cp /usr/share/zoneinfo/$TZ /etc/localtime \
+  && echo "$TZ" > /etc/timezone
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -29,6 +29,7 @@ RUN tlmgr install \
 
 FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 ENV PATH /usr/local/bin/texlive:$PATH
+ENV TZ=Asia/Tokyo
 WORKDIR /workdir
 COPY --from=installer /usr/local/texlive /usr/local/texlive
 RUN apk add --no-cache \
@@ -37,7 +38,10 @@ RUN apk add --no-cache \
   git \
   openssh \
   npm \
-  wget
+  tzdata \
+  wget \
+  && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+  && echo "Asia/Tokyo" > /etc/timezone
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -33,14 +33,14 @@ ENV TZ=Asia/Tokyo
 WORKDIR /workdir
 COPY --from=installer /usr/local/texlive /usr/local/texlive
 RUN apt-get update \
-  && apt-get install -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   perl \
   wget \
   git \
   ssh \
   tzdata \
-  && ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
-  && echo "Asia/Tokyo" > /etc/timezone \
+  && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime \
+  && echo "$TZ" > /etc/timezone \
   && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -29,6 +29,7 @@ RUN tlmgr install \
 
 FROM node:24-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c
 ENV PATH /usr/local/bin/texlive:/npm/node_modules/.bin:$PATH
+ENV TZ=Asia/Tokyo
 WORKDIR /workdir
 COPY --from=installer /usr/local/texlive /usr/local/texlive
 RUN apt-get update \
@@ -37,6 +38,9 @@ RUN apt-get update \
   wget \
   git \
   ssh \
+  tzdata \
+  && ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+  && echo "Asia/Tokyo" > /etc/timezone \
   && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm


### PR DESCRIPTION
## 概要

コンテナイメージのタイムゾーンを **JST(`Asia/Tokyo`, UTC+9)** に設定します。

resolve #63

## 背景

alpine / debian 両イメージとも `TZ` / `tzdata` が未設定で **デフォルト UTC** で動作していました。卒論環境では日本時間とのズレにより以下が問題になります:

- `\today` が深夜帯(JST 00:00〜09:00)に前日表示になりうる
- 生成 PDF のメタデータ・ログ・`latexmk` のタイムスタンプが JST と 9 時間ズレる
- コンテナ内の `date` / git commit のタイムスタンプが UTC

## 変更内容

両 Dockerfile の **最終ステージ**に以下を追加:

- `ENV TZ=Asia/Tokyo`
- `tzdata` パッケージ追加
- `/etc/localtime`(Asia/Tokyo へ symlink/コピー)・`/etc/timezone` 設定

| ファイル | base | 方法 |
|---|---|---|
| `alpine/Dockerfile` | `alpine:3.22.2` | `apk add tzdata` + `cp .../Asia/Tokyo /etc/localtime` |
| `debian/Dockerfile` | `node:24-trixie-slim` | `apt-get install tzdata` + `ln -sf .../Asia/Tokyo /etc/localtime` |

## 動作確認

両ステージの TZ 設定部分を同一 base イメージで最小ビルドし、`date` を検証(ローカル):

```
ALPINE  date: Fri Jun  5 03:19:01 JST 2026  | +0900 JST | /etc/timezone=Asia/Tokyo
DEBIAN  date: Fri Jun  5 03:19:04 JST 2026  | +0900 JST | /etc/timezone=Asia/Tokyo
```

いずれも JST(+0900)で表示されることを確認済みです。フルイメージのビルド/テストは CI(`build-pr.yml`)で実施されます。

## 補足

`tzdata` 追加によるイメージサイズ増は数 MB 程度です。サイズを厳密に抑えたい場合は zoneinfo コピー後に `tzdata` を削除する構成も可能ですが、メンテナンス性を優先して本 PR では `tzdata` を残しています。
