### PR TITLE
Bump alpine base image to 3.23.4

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 AS installer
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS installer
 ENV PATH /usr/local/bin/texlive:$PATH
 WORKDIR /install-tl-unx
 RUN apk add --no-cache \
@@ -27,7 +27,7 @@ RUN tlmgr install \
   lm \
   latexmk
 
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 ENV PATH /usr/local/bin/texlive:$PATH
 ENV TZ=Asia/Tokyo
 WORKDIR /workdir


### PR DESCRIPTION
## 概要

`alpine/Dockerfile` のベースイメージを `3.22.2` → **`3.23.4`** に更新し、エコシステム全体で alpine のバージョンを揃えます。

resolve #65

## 背景

`thesis-management-tools` で alpine ベースを `3.23.4` に更新済み([thesis-management-tools#436](https://github.com/smkwlab/thesis-management-tools/pull/436))の一方、本リポジトリは `3.22.2` のままでズレていました。再現性・保守性のため統一します。

## 変更内容

`alpine/Dockerfile` の2箇所(installer ステージ・最終ステージ)の `FROM` を更新:

```
- alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+ alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
```

- digest は **マルチアーキ index(`oci.image.index.v1`)** ダイジェストで、従来同様 amd64 / arm64 両対応。

## 動作確認(ローカル)

`3.23.4` の index digest 解決と、installer/最終ステージで使用する apk パッケージの可用性を確認:

- ✅ digest 解決 → `/etc/alpine-release` = `3.23.4`
- ✅ `apk add perl tar wget xz fontconfig`(installer)成功
- ✅ `apk add bash perl git openssh npm tzdata wget`(最終)成功
- ✅ `npm --version` → 11.11.0

フルイメージ(TeXLive 込み)のビルド/テストは CI(`build-pr.yml`)で実施されます。

## 補足

`debian/Dockerfile` は本 PR の対象外(Issue #65 の通り alpine 版のみ)。
