### PR TITLE
Retry install-tl download with fail-fast wget

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,7 +8,13 @@ RUN apk add --no-cache \
   xz \
   fontconfig
 COPY ./texlive.profile ./
-RUN wget -nv https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+RUN ok=0; \
+    for i in 1 2 3 4 5; do \
+      if wget -nv --timeout=30 --tries=2 https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      echo "install-tl download attempt $i failed, retrying in 5s..."; \
+      sleep 5; \
+    done; \
+    [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
 RUN ./install-tl --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -8,7 +8,13 @@ RUN apt-get update && \
   xz-utils \
   fontconfig
 COPY ./texlive.profile ./
-RUN wget -nv https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+RUN ok=0; \
+    for i in 1 2 3 4 5; do \
+      if wget -nv --timeout=30 --tries=2 https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      echo "install-tl download attempt $i failed, retrying in 5s..."; \
+      sleep 5; \
+    done; \
+    [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
 RUN ./install-tl --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \


### PR DESCRIPTION
## 概要

TeXLive インストーラ取得 `wget` を **fail-fast 化 + シェルリトライ**でラップし、CTAN ミラー一過性障害による長時間ハング/CI 失敗を抑制します。

resolve #68

## 背景

`mirror.ctan.org` はランダムなミラーへのリダイレクタで、到達不能なミラーに当たると `wget` のデフォルト挙動で **~47分リトライしてから失敗**していました(実例: PR #61 / #66 の `build-debian`)。

## 変更内容

両 Dockerfile(alpine / debian)の `install-tl-unx.tar.gz` 取得を以下に変更:

```dockerfile
RUN ok=0; \
    for i in 1 2 3 4 5; do \
      if wget -nv --timeout=30 --tries=2 https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
      echo "install-tl download attempt $i failed, retrying in 5s..."; \
      sleep 5; \
    done; \
    [ "$ok" = 1 ]
```

- `--timeout=30 --tries=2` で **1試行あたり最大 ~60秒**に短縮(fail-fast)。
- シェルで最大5回リトライ。`mirror.ctan.org` は毎回別ミラーへリダイレクトされるため、不調ミラーを引き直して成功確率を上げる。
- 全試行失敗時は `[ "$ok" = 1 ]` で**明示的にビルドを失敗**させる(部分DLでの誤通過を防止)。
- 最悪ケースを **数十分 → 数分**に抑制。

## 動作確認(ローカル)

alpine / debian 両 base で最小ビルドし、wget フラグ受理・DL 成功・tarball 展開(`install-tl` 存在)を確認:

- ✅ ALPINE(`alpine:3.23.4`, GNU wget via apk): BUILD OK
- ✅ DEBIAN(`node:24-trixie-slim`, GNU wget via apt): BUILD OK

※ 両 Dockerfile とも `wget` パッケージを明示導入(= GNU wget)しているため、`--timeout` / `--tries` は両 base で利用可能。フルイメージのビルド/テストは CI で実施されます。

## スコープ / フォローアップ

- 本 PR は Issue #68 の **案A(fail-fast + リトライ)** のみ。`install-tl` / `tlmgr` のパッケージ取得ミラー固定(案B/C)は単一障害点リスクがあるため見送り、必要なら別途対応。
- 同じ取得は `build-tag.yml`(本番ビルド)も両 Dockerfile を使うため、本変更でカバーされます。
