### PR TITLE
Pin install-tl --repository to frozen 2025 tlnet-final mirror

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,11 @@
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS installer
 ENV PATH /usr/local/bin/texlive:$PATH
+# Pin the TeXLive repository to a frozen historic tlnet-final mirror.
+# This makes install-tl fetch the installer tarball, texlive.tlpdb and every
+# package from a single stable host, eliminating the mirror.ctan.org
+# double-random-redirect failures (#68/#70), and freezes the TeXLive version
+# (2025) so image builds stay reproducible even after a new annual release.
+ARG TL_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final
 WORKDIR /install-tl-unx
 RUN apk add --no-cache \
   perl \
@@ -10,13 +16,13 @@ RUN apk add --no-cache \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz ${TL_REPO}/install-tl-unx.tar.gz; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \
     [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --profile=texlive.profile
+RUN ./install-tl --repository=${TL_REPO} --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,13 +16,13 @@ RUN apk add --no-cache \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz ${TL_REPO}/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz "${TL_REPO}/install-tl-unx.tar.gz"; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \
     [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --repository=${TL_REPO} --profile=texlive.profile
+RUN ./install-tl --repository="${TL_REPO}" --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,11 @@
 FROM debian:13.1-slim@sha256:a347fd7510ee31a84387619a492ad6c8eb0af2f2682b916ff3e643eb076f925a AS installer
 ENV PATH /usr/local/bin/texlive:$PATH
+# Pin the TeXLive repository to a frozen historic tlnet-final mirror.
+# This makes install-tl fetch the installer tarball, texlive.tlpdb and every
+# package from a single stable host, eliminating the mirror.ctan.org
+# double-random-redirect failures (#68/#70), and freezes the TeXLive version
+# (2025) so image builds stay reproducible even after a new annual release.
+ARG TL_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final
 WORKDIR /install-tl-unx
 RUN apt-get update && \
     apt-get install -y \
@@ -10,13 +16,13 @@ RUN apt-get update && \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz ${TL_REPO}/install-tl-unx.tar.gz; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \
     [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --profile=texlive.profile
+RUN ./install-tl --repository=${TL_REPO} --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && \
 COPY ./texlive.profile ./
 RUN ok=0; \
     for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz ${TL_REPO}/install-tl-unx.tar.gz; then ok=1; break; fi; \
+      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz "${TL_REPO}/install-tl-unx.tar.gz"; then ok=1; break; fi; \
       echo "install-tl download attempt $i failed, retrying in 5s..."; \
       sleep 5; \
     done; \
     [ "$ok" = 1 ]
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --repository=${TL_REPO} --profile=texlive.profile
+RUN ./install-tl --repository="${TL_REPO}" --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \


### PR DESCRIPTION
## 背景

#69(案A)で installer tarball 取得の `wget` を fail-fast + リトライ化したが、PR #69 の CI で**別ステップの失敗**が観測された:

- `wget ... install-tl-unx.tar.gz` → `mirror.latigo.net` から DL 成功 ✅
- 次の `install-tl --profile=texlive.profile` → `texlive.tlpdb` を**別ミラー `mirrors.mit.edu` から取得しようとしてタイムアウト**(~16分後 exit 1)❌

`mirror.ctan.org` は**リクエストごとに別ミラーへリダイレクト**するため、tarball と tlpdb / 各パッケージが**別々のミラーに分散**し、片方が不調だと失敗する。

## 変更内容(Issue #70 の提案2: tlnet-final 固定)

`ARG TL_REPO` を導入し、**凍結済み historic tlnet-final ミラー(TeXLive 2025)**を、tarball 取得と `install-tl --repository` の**両方**に使用する。

```dockerfile
ARG TL_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final
RUN wget ... -O install-tl-unx.tar.gz ${TL_REPO}/install-tl-unx.tar.gz ...
RUN ./install-tl --repository=${TL_REPO} --profile=texlive.profile
```

- **alpine / debian 両 Dockerfile に適用**(`build-tag.yml` 本番ビルドは両方を使用するためカバー)。
- `tlmgr install` は install-tl が記録した同一リポジトリを既定として利用するため追加変更不要。

## 効果

- tarball・tlpdb・全パッケージを**単一の安定ホスト**から取得 → **二重ランダムリダイレクト由来の失敗を根治**。
- TeXLive バージョンを **2025 に凍結** → 2026 が live tlnet に出た後もビルドが**再現可能**(現行公開イメージ 2025b と一致)。

## なぜ 2025/tlnet-final か

- live `mirror.ctan.org/.../tlnet` は **2026-03 リリースで既に TeXLive 2026 を配信中**。放置すると次回ビルドで意図せず 2026 に切り替わる。
- 2025/tlnet-final は **2026-03-01 に凍結済み**で immutable。`install-tl-unx.tar.gz` + `tlpkg/`(tlpdb)+ `archive/` を全て含む完全な自己完結リポジトリであることを確認済み(両 URL とも HTTP 200)。

## 検証

- [x] 凍結リポジトリの `install-tl-unx.tar.gz` / `tlpkg/texlive.tlpdb` の到達性を確認(HTTP 200)
- [ ] CI による alpine / debian 両イメージのフルビルド(#68/#69 の失敗が再現した環境そのもの)

## トレードオフ / 今後の課題

- 単一ホスト(`ftp.math.utah.edu`)固定は**単一障害点**になりうる。将来的に Renovate での年版追従、フォールバックミラー設計を別 Issue で検討する余地あり。

Closes #70