### PR TITLE
Skip unaffected variant builds in PR CI via path filtering

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,7 +8,34 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      alpine: ${{ steps.filter.outputs.alpine }}
+      debian: ${{ steps.filter.outputs.debian }}
+    steps:
+      # On pull_request events paths-filter lists changed files via the API,
+      # so no checkout is required here.
+      - name: Detect changed variants
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            shared: &shared
+              - '.github/actions/build/**'
+              - '.github/workflows/build-pr.yml'
+              - 'tests/**'
+            alpine:
+              - *shared
+              - 'alpine/**'
+            debian:
+              - *shared
+              - 'debian/**'
   build-alpine:
+    needs: changes
+    if: ${{ needs.changes.outputs.alpine == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,6 +63,8 @@ jobs:
           name: alpine
           path: ./test-run/main.pdf
   build-debian:
+    needs: changes
+    if: ${{ needs.changes.outputs.debian == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,6 +93,8 @@ jobs:
           name: debian
           path: ./test-run/main.pdf
   build-debian-arm64:
+    needs: changes
+    if: ${{ needs.changes.outputs.debian == 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout


### PR DESCRIPTION
## 概要

PR CI(`build-pr.yml`)で**変更されたバリアントのビルドのみ**を実行するようにし、無関係なフルビルド(TeXLive 込みで十数分)を抑制する。

## 採用方針: 案A(単一ワークフロー + `dorny/paths-filter`)

Issue #67 の案A/案Bのうち、以下の理由で**案A**を採用:

- 共有パスを **YAML アンカーで一元管理**(案Bの2ファイル重複・ドリフトを回避)
- 将来 required status checks を導入する際、集約ゲートジョブで `skipped` を正しく扱える(案Bの「paths 不一致でワークフロー不起動 → 永久 pending」問題を回避)
- 3ジョブが同じ composite action・Test ステップを共有しており1ファイル管理が保守的

## 変更内容

`changes` ジョブ(`dorny/paths-filter@v4.0.1`、SHA ピン)で変更を検出し、各ビルドジョブを条件実行:

| ジョブ | 実行条件 |
|---|---|
| `build-alpine` | `alpine` フィルタ一致時 |
| `build-debian` | `debian` フィルタ一致時 |
| `build-debian-arm64` | `debian` フィルタ一致時 |

### パスとバリアントの対応

- `alpine/**` → alpine のみ
- `debian/**` → debian / debian-arm64 のみ
- 共有パス(両方を実行)— YAML アンカー `&shared` で一元定義:
  - `.github/actions/build/**`(共通 composite action)
  - `.github/workflows/build-pr.yml`(ワークフロー自身)
  - `tests/**`(両バリアントの動作確認に使用)

## 検証

- [x] `actionlint` で YAML パース・ジョブ/needs/if 構文を確認(新規変更にエラーなし。既存 Test ステップの SC2086 info は本 Issue 対象外)
- [x] `filters` のアンカー展開をローカル検証: `alpine={shared+alpine/**}`、`debian={shared+debian/**}`、**クロスリークなし**
- [x] 本 PR は `build-pr.yml`(共有パス)を変更 → **alpine/debian 両方がビルドされる**ことで、ゲートが誤って全スキップしないことを実地確認

## 補足

- `build-tag.yml`(tag push の本番ビルド)は全バリアント常時ビルドのまま**変更なし**。
- main に required status checks は未設定のため、ジョブ `skipped` でもマージはブロックされない(Issue 記載の前提どおり)。

resolve #67