### PR TITLE
Update README.md version tags to 2026a

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Supported tags / タグ一覧
 
 ### 推奨イメージ
-- [`latest`, `2025i`](./debian/Dockerfile)
+- [`latest`, `2026a`](./debian/Dockerfile)
   - お使いの環境に合わせて自動的に最適なイメージを選択
   - Intel Mac/Windows: 軽量・高速版
   - Apple Silicon Mac: 互換性重視版
 
 ### 個別指定イメージ
-- [`alpine`, `2025i-alpine`](./alpine/Dockerfile)
+- [`alpine`, `2026a-alpine`](./alpine/Dockerfile)
   - Intel Mac/Windows専用（軽量・高速）
   - Apple Silicon Macでは動作しません
-- [`debian`, `2025i-debian`](./debian/Dockerfile)
+- [`debian`, `2026a-debian`](./debian/Dockerfile)
   - すべての環境で動作（互換性重視）
 
 ## Install / インストール
@@ -25,9 +25,9 @@ GitHub Container Registry からインストールできます。
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2025i
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026a
 
-# 最新版（2025iと同じ）
+# 最新版（2026aと同じ）
 docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 ```
 
@@ -35,7 +35,7 @@ docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2025i \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026a \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 
 # latest タグでも同じ結果


### PR DESCRIPTION
## 概要

新イメージ `2026a` のリリースに伴い、README.md のバージョン参照を `2025i` から `2026a` に更新します。

## 変更内容

- Supported tags 一覧（`latest`/`alpine`/`debian`）のタグ表記を `2026a` 系に更新
- Install / Usage セクションの `docker pull` / `docker run` 例を `2026a` に更新

## リリース状況

- `2026a` タグは push 済みで、`build-tag.yml` によるビルドが成功しています
- ghcr.io に linux/amd64 + linux/arm64 のマルチアーキマニフェストが公開済みです
  - `ghcr.io/smkwlab/texlive-ja-textlint:2026a`

## `2025i` からの主な変更点

| PR | 内容 |
|----|------|
| #71 | install-tl を frozen 2025 tlnet-final mirror に pin |
| #69 | install-tl ダウンロードを fail-fast wget でリトライ |
| #66 | alpine ベースイメージを 3.23.4 に更新 |
| #64 | コンテナのタイムゾーンを JST (Asia/Tokyo) に設定 |
| #58 | Node.js ランタイムを 20→24 (LTS) に更新 |