### PR TITLE
ci: re-review on push (add synchronize)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -6,7 +6,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing every push
+    types: [opened, reopened, ready_for_review, synchronize]   # synchronize: re-review on each push. Drop if cost is a concern.
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
AI レビューを push のたびに再実行するよう `synchronize` をトリガに追加（smkwlab/.github#55 に追従）。連続 push 時は concurrency が古い実行をキャンセルします。