### PR TITLE
Use npm ci instead of npm install in Dockerfiles

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -57,6 +57,6 @@ RUN apk add --no-cache \
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
-RUN npm install /npm
+RUN npm ci --prefer-offline --no-audit
 WORKDIR /workdir
 CMD ["bash"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -57,6 +57,6 @@ RUN apk add --no-cache \
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
-RUN npm ci --prefer-offline --no-audit
+RUN npm ci --no-audit
 WORKDIR /workdir
 CMD ["bash"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -57,6 +57,6 @@ RUN apt-get update \
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
-RUN npm ci --prefer-offline --no-audit
+RUN npm ci --no-audit
 WORKDIR /workdir
 CMD ["bash"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -57,6 +57,6 @@ RUN apt-get update \
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
-RUN npm install /npm
+RUN npm ci --prefer-offline --no-audit
 WORKDIR /workdir
 CMD ["bash"]


### PR DESCRIPTION
resolve #79

`alpine/Dockerfile:60` と `debian/Dockerfile:60` の `npm install /npm` を `npm ci --no-audit` に変更しました。`package-lock.json` をコミットしているにもかかわらず `npm install` ではロックファイルが更新され得るため、再現性が保証されていませんでした。

- WORKDIR は `/npm` で、直前に `package.json` と `package-lock.json` を配置済みのため `npm ci`（引数なし）が lock 通りに依存解決します
- `--no-audit` でインストール時間も短縮（脆弱性追従は運用中の Renovate が担当）
- 生成される `/npm/node_modules` は従来と等価（textlint 等の依存は同一）

> 注: 初版では `--prefer-offline` も付けていましたが、BuildKit のキャッシュマウントを使わない通常の Docker ビルドでは無効でレビュー指摘を受けたため削除しました。

## 検証

Docker ビルド CI（build-alpine / build-debian / build-debian-arm64）すべて pass。
加えて、`npm install /npm`（＝自ディレクトリをパッケージ指定）と `npm ci` の結果を node:24-alpine で実測比較し、**`node_modules` が完全一致・`textlint` も同一バージョン（v14.8.4）で存在**することを確認済み（挙動変化なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
