### PR TITLE
chore: update thesis-management-tools references → student-repo-management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ docker build -t test-image . && docker run --rm test-image textlint --version
 - **latex-environment**: Primary consumer
 - **sotsuron-template**: Via latex-environment  
 - **wr-template**: Weekly reports
-- **thesis-management-tools**: Automated builds
+- **student-repo-management**: Automated builds
 
 ## Detailed Documentation
 

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -147,7 +147,7 @@ docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile .
 - **latex-environment**: Primary consumer of these images
 - **sotsuron-template**: Indirect dependency through latex-environment
 - **wr-template**: Uses for weekly reports
-- **thesis-management-tools**: Uses for automated builds
+- **student-repo-management**: Uses for automated builds
 
 ### Update Coordination
 ```


### PR DESCRIPTION
## 概要

リポジトリ改名 smkwlab/student-repo-management#504（旧 `thesis-management-tools`）に伴う参照追随。CLAUDE.md / docs/CLAUDE-DEVELOPMENT.md の相互参照を更新。

Refs smkwlab/student-repo-management#504