### PR TITLE
docs: refresh current version references to 2026a

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ docker build -f alpine/Dockerfile -t texlive-ja-textlint:alpine .
 docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2025b --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026a --push .
 ```
 
 ### Test Compilation
@@ -28,8 +28,8 @@ docker run --rm -v $(pwd)/tests:/workspace -w /workspace texlive-ja-textlint:alp
 ### Registry Operations
 ```bash
 # Push to registry (maintainers only)
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2025b
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2025b
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
 ```
 
 ## Image Structure
@@ -46,8 +46,8 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2025b
 ## Version Management
 
 ### Current Tags
-- `2025b` - Current stable release
-- `2025a` - Previous update
+- `2026a` - Current stable release (also published as `latest`)
+- `2025i` - Previous update
 - Multi-architecture: AMD64, ARM64
 
 ### Version Checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
 ## Version Management
 
 ### Current Tags
-- `2026a` - Current stable release (also published as `latest`)
+- `2026a` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
 - `2025i` - Previous update
 - Multi-architecture: AMD64, ARM64
 

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -24,11 +24,13 @@ This document covers the development workflow, architecture, and technical detai
 ## Version Strategy
 
 ### Calendar Versioning
-Tags follow TeXLive release patterns:
+Tags combine the release year with a sequential letter for updates within
+that year (`2025`, `2025a`, ..., `2025i`, `2026a`, ...):
 - `2025` - Major TeXLive 2025 release
-- `2025a` - First update with additional packages/fixes
-- `2025b` - Second update (current)
-- `2025c` - Potential third update
+- `2025a`-`2025i` - Successive updates during 2025
+- `2026a` - Current stable release (also published as `latest`)
+
+See [README.md](../README.md) for the tags currently published on the registry.
 
 ### Backward Compatibility
 - Previous major versions maintained for 1 year

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -16,7 +16,7 @@ docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 docker build -f alpine/Dockerfile -t my-texlive:latest .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2025b --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026a --push .
 ```
 
 ### Running Containers
@@ -34,13 +34,13 @@ docker run --rm -v $(pwd)/my-thesis:/workspace -w /workspace texlive-ja-textlint
 ### Registry Operations
 ```bash
 # Tag for registry
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2025b
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026a
 
 # Push to GitHub Container Registry
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2025b
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
 
 # Pull from registry
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2025b
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026a
 ```
 
 ## LaTeX Compilation Examples


### PR DESCRIPTION
## 概要

README.md は最新タグ `2026a` に更新済みですが、CLAUDE.md と docs/ に `2025b` を「current」とする記述が取り残されていたため修正します。

## 変更内容

- **CLAUDE.md**
  - build / tag / push のコマンド例: `...:2025b` → `...:2026a`（3箇所）
  - Current Tags セクション: `2026a` を current stable（`latest` としても公開）、`2025i` を previous に更新
- **docs/CLAUDE-DEVELOPMENT.md**
  - Calendar Versioning セクションを実タグ一覧（`2025`〜`2025i`、`2026a`）に基づき書き直し。命名規則（年 + 連番英字）と最新版が分かる形にし、公開中のタグ一覧は README.md への参照に変更
- **docs/CLAUDE-EXAMPLES.md**
  - registry 操作のコマンド例: `...:2025b` → `...:2026a`（4箇所）

## 変更しない箇所

- docs/CLAUDE-TROUBLESHOOTING.md の `2025c-test` はシェルのエラー出力例（歴史的記述）のため維持
- TeXLive 本体のバージョン記述（TeXLive 2025）は Dockerfile が TeXLive 2025 リポジトリ固定のままのため変更なし

## 検証

- `command grep -rn "2025b" CLAUDE.md docs/` → 残存ゼロ
- current / latest を謳う行はすべて `2026a` に統一済み

https://claude.ai/code/session_01PGcVXHJSHMBx4ki8WU2ZiS