### PR TITLE
fix: fall back to alternate TUG historic mirrors

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,11 +1,15 @@
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS installer
 ENV PATH /usr/local/bin/texlive:$PATH
-# Pin the TeXLive repository to a frozen historic tlnet-final mirror.
-# This makes install-tl fetch the installer tarball, texlive.tlpdb and every
-# package from a single stable host, eliminating the mirror.ctan.org
-# double-random-redirect failures (#68/#70), and freezes the TeXLive version
-# (2025) so image builds stay reproducible even after a new annual release.
-ARG TL_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final
+# Pin the TeXLive repository to a frozen historic tlnet-final snapshot.
+# Serving the installer tarball, texlive.tlpdb and every package from one host
+# eliminates the mirror.ctan.org double-random-redirect failures (#68/#70), and
+# the frozen 2025 snapshot keeps builds reproducible across annual releases.
+# One host is a single point of failure though (#95), so try the TUG historic
+# mirrors in turn; whichever serves the tarball also serves install-tl.
+# Set TL_REPO to a full tlnet-final URL to bypass the list entirely.
+ARG TL_REPO=
+ARG TL_MIRRORS="https://ftp.tu-chemnitz.de/pub/tug/historic https://texlive.info/historic https://pi.kwarc.info/historic https://ftp.math.utah.edu/pub/tex/historic"
+ARG TL_SNAPSHOT=systems/texlive/2025/tlnet-final
 WORKDIR /install-tl-unx
 RUN apk add --no-cache \
   perl \
@@ -14,15 +18,30 @@ RUN apk add --no-cache \
   xz \
   fontconfig
 COPY ./texlive.profile ./
-RUN ok=0; \
-    for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz "${TL_REPO}/install-tl-unx.tar.gz"; then ok=1; break; fi; \
-      echo "install-tl download attempt $i failed, retrying in 5s..."; \
+# Bounded worst case: two passes over the list, one short attempt per mirror
+# (~25s against a blackholed host), so a total outage fails in minutes.
+RUN set -e; \
+    if [ -n "${TL_REPO}" ]; then \
+      candidates="${TL_REPO}"; \
+    else \
+      candidates=""; \
+      for mirror in ${TL_MIRRORS}; do candidates="${candidates} ${mirror}/${TL_SNAPSHOT}"; done; \
+    fi; \
+    for pass in 1 2; do \
+      for repo in ${candidates}; do \
+        echo "Fetching install-tl from ${repo} (pass ${pass})"; \
+        if wget -nv --timeout=20 --tries=1 -O install-tl-unx.tar.gz "${repo}/install-tl-unx.tar.gz"; then \
+          echo "${repo}" > /tl-repo; \
+          break 2; \
+        fi; \
+        echo "mirror unavailable: ${repo}"; \
+      done; \
       sleep 5; \
     done; \
-    [ "$ok" = 1 ]
+    if [ ! -s /tl-repo ]; then echo "no usable TeXLive mirror"; exit 1; fi; \
+    echo "Using TeXLive repository: $(cat /tl-repo)"
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --repository="${TL_REPO}" --profile=texlive.profile
+RUN ./install-tl --repository="$(cat /tl-repo)" --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,11 +1,15 @@
 FROM debian:13.5-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2 AS installer
 ENV PATH /usr/local/bin/texlive:$PATH
-# Pin the TeXLive repository to a frozen historic tlnet-final mirror.
-# This makes install-tl fetch the installer tarball, texlive.tlpdb and every
-# package from a single stable host, eliminating the mirror.ctan.org
-# double-random-redirect failures (#68/#70), and freezes the TeXLive version
-# (2025) so image builds stay reproducible even after a new annual release.
-ARG TL_REPO=https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final
+# Pin the TeXLive repository to a frozen historic tlnet-final snapshot.
+# Serving the installer tarball, texlive.tlpdb and every package from one host
+# eliminates the mirror.ctan.org double-random-redirect failures (#68/#70), and
+# the frozen 2025 snapshot keeps builds reproducible across annual releases.
+# One host is a single point of failure though (#95), so try the TUG historic
+# mirrors in turn; whichever serves the tarball also serves install-tl.
+# Set TL_REPO to a full tlnet-final URL to bypass the list entirely.
+ARG TL_REPO=
+ARG TL_MIRRORS="https://ftp.tu-chemnitz.de/pub/tug/historic https://texlive.info/historic https://pi.kwarc.info/historic https://ftp.math.utah.edu/pub/tex/historic"
+ARG TL_SNAPSHOT=systems/texlive/2025/tlnet-final
 WORKDIR /install-tl-unx
 RUN apt-get update && \
     apt-get install -y \
@@ -14,15 +18,30 @@ RUN apt-get update && \
   xz-utils \
   fontconfig
 COPY ./texlive.profile ./
-RUN ok=0; \
-    for i in 1 2 3 4 5; do \
-      if wget -nv --timeout=30 --tries=2 -O install-tl-unx.tar.gz "${TL_REPO}/install-tl-unx.tar.gz"; then ok=1; break; fi; \
-      echo "install-tl download attempt $i failed, retrying in 5s..."; \
+# Bounded worst case: two passes over the list, one short attempt per mirror
+# (~25s against a blackholed host), so a total outage fails in minutes.
+RUN set -e; \
+    if [ -n "${TL_REPO}" ]; then \
+      candidates="${TL_REPO}"; \
+    else \
+      candidates=""; \
+      for mirror in ${TL_MIRRORS}; do candidates="${candidates} ${mirror}/${TL_SNAPSHOT}"; done; \
+    fi; \
+    for pass in 1 2; do \
+      for repo in ${candidates}; do \
+        echo "Fetching install-tl from ${repo} (pass ${pass})"; \
+        if wget -nv --timeout=20 --tries=1 -O install-tl-unx.tar.gz "${repo}/install-tl-unx.tar.gz"; then \
+          echo "${repo}" > /tl-repo; \
+          break 2; \
+        fi; \
+        echo "mirror unavailable: ${repo}"; \
+      done; \
       sleep 5; \
     done; \
-    [ "$ok" = 1 ]
+    if [ ! -s /tl-repo ]; then echo "no usable TeXLive mirror"; exit 1; fi; \
+    echo "Using TeXLive repository: $(cat /tl-repo)"
 RUN tar -xzf ./install-tl-unx.tar.gz --strip-components=1
-RUN ./install-tl --repository="${TL_REPO}" --profile=texlive.profile
+RUN ./install-tl --repository="$(cat /tl-repo)" --profile=texlive.profile
 RUN ln -sf /usr/local/texlive/*/bin/* /usr/local/bin/texlive
 RUN tlmgr install \
   collection-fontsrecommended \


### PR DESCRIPTION
## 概要

固定していた `ftp.math.utah.edu` が停止し、debian / alpine の全ビルドが失敗していた。単一ミラーへの依存をやめ、公式 TUG historic ミラーを順に試すようにする。

Resolves #95

## 変更内容

`debian/Dockerfile` と `alpine/Dockerfile` の installer ステージ（両者同一）:

```dockerfile
ARG TL_REPO=
ARG TL_MIRRORS="https://ftp.tu-chemnitz.de/pub/tug/historic https://texlive.info/historic https://pi.kwarc.info/historic https://ftp.math.utah.edu/pub/tex/historic"
ARG TL_SNAPSHOT=systems/texlive/2025/tlnet-final
```

- 候補を順に試し、**成功したミラーを `/tl-repo` に記録して `install-tl --repository` にも渡す**。#68 / #70 で解決した「tarball と `texlive.tlpdb` が別ミラーに分散して失敗する」性質を維持する
- `TL_REPO` を指定した場合はリストを迂回し、そのミラーだけを使う（デバッグ・再現用）
- `TL_SNAPSHOT` を分離したため、TeX Live のバージョンを変える際は1行の変更で済む（#96）
- 全滅時は2巡して打ち切り、`no usable TeXLive mirror` で失敗する

TeX Live 2025 tlnet-final への固定は維持しており、**イメージの中身は変わらない**。

## ミラー選定

[tug.org/historic](https://tug.org/historic/) 掲載の全ミラーを実測し、生存していたものを応答の速い順に並べた。utah も末尾に残してあるので、復旧すれば再び使われる。

| ミラー | 実測 | `archive/` | `tlpkg/texlive.tlpdb.xz` |
|---|---|---|---|
| ftp.tu-chemnitz.de/pub/tug/historic | 200 / 0.80s | ✅ | ✅ |
| texlive.info/historic | 200 / 0.92s | ✅ | ✅ |
| pi.kwarc.info/historic | 200 / 1.88s | ✅ | ✅ |
| ftp.math.utah.edu/pub/tex/historic | ❌ タイムアウト | — | — |

`mirrors.tuna.tsinghua.edu.cn` と `mirror.nju.edu.cn` も生存していたが、4件で十分な冗長性があるため見送った。

## 検証

### シェルロジック（alpine / debian 両方で実測）

busybox wget と GNU wget で挙動が異なるため両方で確認した。

| ケース | 結果 |
|---|---|
| 正常系（alpine / busybox） | 先頭ミラーから 3.9 秒で取得。`break 2` は busybox ash でも動作 |
| フェイルオーバ（debian） | utah が 25.5 秒でタイムアウト → chemnitz へ切り替えて成功 |
| `TL_REPO` 明示指定 | リストを迂回し指定ミラーのみ使用 |
| 全ミラー死亡 | `no usable TeXLive mirror` で 113 秒で失敗 |

全滅時の所要時間は、従来の単一ミラー構成（最大 ~320 秒）より短い。

### installer ステージの完全ビルド

```
$ docker build --no-cache --target installer -f debian/Dockerfile ./debian/
...
#13 DONE 3296.2s
BUILD_EXIT=0
```

`install-tl` 本体と `tlmgr` のコレクション取得まで通ることを確認した。生成イメージの中身:

```
$ docker run --rm tltest-installer cat /tl-repo
https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2025/tlnet-final

$ docker run --rm tltest-installer tlmgr --version
TeX Live (https://tug.org/texlive) version 2025

$ docker run --rm tltest-installer sh -c 'ls /usr/local/bin/texlive/ | grep -E "^(uplatex|platex|latexmk)$"'
latexmk
platex
uplatex
```

## 関連

- #96 — TeX Live 2026 への移行時期の判断（本 PR とは独立。TL2026 は `tlnet-final` が未作成のため、ここでは TL2025 固定を維持している）
- #93 — 本 PR の merge 後に再実行すればビルドが通るはず
