### PR TITLE
docs: refresh current version references to 2026b

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ docker build -f alpine/Dockerfile -t texlive-ja-textlint:alpine .
 docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026a --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026b --push .
 ```
 
 ### Test Compilation
@@ -28,8 +28,8 @@ docker run --rm -v $(pwd)/tests:/workspace -w /workspace texlive-ja-textlint:alp
 ### Registry Operations
 ```bash
 # Push to registry (maintainers only)
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026a
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
 ```
 
 ## Image Structure
@@ -46,8 +46,8 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
 ## Version Management
 
 ### Current Tags
-- `2026a` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
-- `2025i` - Previous update
+- `2026b` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
+- `2026a` - Previous update
 - Multi-architecture: AMD64, ARM64
 
 ### Version Checking

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Supported tags / タグ一覧
 
 ### 推奨イメージ
-- [`latest`, `2026a`](./debian/Dockerfile)
+- [`latest`, `2026b`](./debian/Dockerfile)
   - お使いの環境に合わせて自動的に最適なイメージを選択
   - Intel Mac/Windows: 軽量・高速版
   - Apple Silicon Mac: 互換性重視版
 
 ### 個別指定イメージ
-- [`alpine`, `2026a-alpine`](./alpine/Dockerfile)
+- [`alpine`, `2026b-alpine`](./alpine/Dockerfile)
   - Intel Mac/Windows専用（軽量・高速）
   - Apple Silicon Macでは動作しません
-- [`debian`, `2026a-debian`](./debian/Dockerfile)
+- [`debian`, `2026b-debian`](./debian/Dockerfile)
   - すべての環境で動作（互換性重視）
 
 ## Install / インストール
@@ -25,9 +25,9 @@ GitHub Container Registry からインストールできます。
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026b
 
-# 最新版（2026aと同じ）
+# 最新版（2026bと同じ）
 docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 ```
 
@@ -35,7 +35,7 @@ docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026a \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026b \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 
 # latest タグでも同じ結果

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -25,10 +25,11 @@ This document covers the development workflow, architecture, and technical detai
 
 ### Calendar Versioning
 Tags combine the release year with a sequential letter for updates within
-that year (`2025`, `2025a`, ..., `2025i`, `2026a`, ...):
+that year (`2025`, `2025a`, ..., `2025i`, `2026a`, `2026b`, ...):
 - `2025` - Major TeXLive 2025 release
 - `2025a`-`2025i` - Successive updates during 2025
-- `2026a` - Current stable release (also published as `latest`)
+- `2026a` - First release of 2026
+- `2026b` - Current stable release (also published as `latest`)
 
 See [README.md](../README.md) for the tags currently published on the registry.
 

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -16,7 +16,7 @@ docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 docker build -f alpine/Dockerfile -t my-texlive:latest .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026a --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026b --push .
 ```
 
 ### Running Containers
@@ -34,13 +34,13 @@ docker run --rm -v $(pwd)/my-thesis:/workspace -w /workspace texlive-ja-textlint
 ### Registry Operations
 ```bash
 # Tag for registry
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026b
 
 # Push to GitHub Container Registry
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
 
 # Pull from registry
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026a
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026b
 ```
 
 ## LaTeX Compilation Examples


### PR DESCRIPTION
## 背景

`2026a` タグは **2026-06-05**（`9e42f33`）に切られたもので、以降 main に **24 コミット**が未リリースのまま溜まっている。イメージ利用者は `ghcr.io/smkwlab/texlive-ja-textlint:2026a` を pull するため、これらはまだ誰にも届いていない。

主な未リリース内容:

| commit | 内容 |
|---|---|
| `183b11d` | textlint 14 → 15（`npm audit` 17 件 → 0 件） |
| `f09cb6b` | debian 13.6-slim |
| `7e360fb` | TUG historic ミラーのフォールバック（#95 の単一障害点対策） |
| `0dd05ba` | Dockerfile を `npm install` → `npm ci` |
| `ab4f3f8` / `ff44796` | alpine 3.24.1 / debian 13.5 |
| 4 件 | node.js イメージの digest 更新 |

## 変更内容

次リリースを `2026b` として、ドキュメント内のタグ参照を更新する。

- `README.md` — タグ一覧、`docker pull` / `docker run` の例
- `CLAUDE.md` — buildx / tag / push の例、Current Tags
- `docs/CLAUDE-EXAMPLES.md` — Registry Operations の例
- `docs/CLAUDE-DEVELOPMENT.md` — Calendar Versioning の一覧

**タグを切る前に**マージすることで、タグが捉えるツリーの時点でドキュメントが正しい状態になる。

## 補足

年号は**イメージのリリース年**であって TeX Live のバージョンではない（Issue #96 に明記）。イメージが内包するのは引き続き TL2025 の凍結スナップショットで、TL2026 への移行判断（#96）とは独立している。

`docs/CLAUDE-DEVELOPMENT.md` では `2026a` を削除せず「First release of 2026」として履歴に残した。`CLAUDE.md` の「Previous update」も `2025i` → `2026a` に繰り上げている。

## リリース後の作業

1. `2026b` タグを push → `build-tag.yml` が alpine / debian / debian-arm64 を ghcr へ publish（`latest` も移動）
2. `update-readme-issue.yml` が README 更新用の issue を自動起票（`2026a` 時の #73 が未 close で残っているため、併せて整理する）
3. `latex-environment` の `devcontainer.json` を追随（日次 cron の `check-texlive-updates.yml` が自動検知する）