### PR TITLE
fix: put textlint on PATH in the alpine variant

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,7 +56,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:alpine \
-            sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -86,7 +86,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:debian \
-            sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -116,7 +116,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:debian-arm64 \
-            sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
 docker run --rm texlive-ja-textlint:alpine tlmgr --version
 
 # Check textlint version
-docker run --rm texlive-ja-textlint:alpine npm list -g textlint
+docker run --rm texlive-ja-textlint:alpine textlint --version
 ```
 
 ## File Structure

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,7 +59,10 @@ RUN tlmgr install \
   latexmk
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ENV PATH /usr/local/bin/texlive:$PATH
+# textlint and friends are installed under /npm, not globally, so their bin
+# directory has to be on PATH for `textlint` to be callable by name (as the
+# debian variant already does).
+ENV PATH /usr/local/bin/texlive:/npm/node_modules/.bin:$PATH
 ENV TZ=Asia/Tokyo
 WORKDIR /workdir
 COPY --from=installer /usr/local/texlive /usr/local/texlive

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -122,7 +122,7 @@ docker run --rm texlive-ja-textlint:alpine node --version
 docker run --rm texlive-ja-textlint:alpine npm --version
 
 # Check textlint version
-docker run --rm texlive-ja-textlint:alpine npm list -g textlint
+docker run --rm texlive-ja-textlint:alpine textlint --version
 ```
 
 ### Package Management

--- a/docs/CLAUDE-TROUBLESHOOTING.md
+++ b/docs/CLAUDE-TROUBLESHOOTING.md
@@ -43,10 +43,10 @@ docker run --rm texlive-ja-textlint:alpine fc-list | grep IPA
 ### textlint Testing
 ```bash
 # Check textlint version
-docker run --rm texlive-ja-textlint:alpine npm list -g textlint
+docker run --rm texlive-ja-textlint:alpine textlint --version
 
 # Check textlint configuration
-docker run --rm texlive-ja-textlint:alpine npx textlint --init
+docker run --rm texlive-ja-textlint:alpine textlint --init
 
 # Test textlint functionality
 cd tests && docker run --rm -v $(pwd):/workspace -w /workspace texlive-ja-textlint:alpine textlint main.tex


### PR DESCRIPTION
Resolves #104

## 問題

alpine イメージでは `textlint` が PATH に載っておらず、コマンド名で起動できなかった。debian の最終ステージは `/npm/node_modules/.bin` を PATH に含んでいたが、alpine は含んでいなかった。

推奨タグは alpine-amd64 + debian-arm64 で構成されるため、**同じ `2026b` でも Apple Silicon では動き、Intel / Windows では失敗する**という形で表面化していた。

## 変更内容

### 1. `alpine/Dockerfile` — PATH に `/npm/node_modules/.bin` を追加

debian と同じ構成に揃えた。

### 2. `build-pr.yml` — CI に textlint の起動確認を追加

3 バリアントのテストが `latexmk` しか実行しておらず、これが検出されなかった原因。`textlint --version` を先頭に置いた。

```diff
-sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
```

### 3. ドキュメントの動かないコマンドを修正

`npm list -g textlint` は 3 ファイルに記載されていたが、パッケージはグローバルではなく `/npm` にローカルインストールされているため空を返していた。

```console
$ docker run --rm <image> npm list -g textlint
/usr/local/lib
`-- (empty)
```

隣接する `npx textlint --init` も、イメージ同梱版ではなく**レジストリから textlint をダウンロードしていた**ため併せて修正した。

```console
$ docker run --rm <image> npx textlint --init
npm warn exec The following package was not found and will be installed: textlint@15.7.1
```

## 検証

TeXLive のフルビルドは CI に任せ、ローカルでは公開済み `2026b-alpine` に本 PR と同じ `ENV PATH` だけを重ねて `ENV` の効果を直接確認した。

**修正前**

```console
$ docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2026b-alpine sh -c 'command -v textlint || echo NOT_ON_PATH'
NOT_ON_PATH
```

**修正後**

```console
$ docker run --rm <PATH適用イメージ> sh -c 'command -v textlint; textlint --version'
/npm/node_modules/.bin/textlint
v15.7.1
```

**実文書での動作**

```console
$ docker run --rm -v $PWD:/workdir <PATH適用イメージ> textlint main.tex
/workdir/main.tex
  87:1  error  Line 87 sentence length(105) exceeds the maximum sentence length of 100.
✖ 1 problem (1 error, 0 warnings, 0 infos)
```

**TeXLive 側への影響がないこと**

```console
$ docker run --rm <PATH適用イメージ> sh -c 'command -v latexmk; command -v uplatex'
/usr/local/bin/texlive/latexmk
/usr/local/bin/texlive/uplatex
```

`/usr/local/bin/texlive` は従来どおり先頭に置いているため、解決順は変わらない。

**CI の追加テストが退行を捕まえること**

```console
$ docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2026b-alpine sh -c 'textlint --version && echo NEVER_REACHED'
sh: textlint: not found
exit=127
```

**差し替えたドキュメントのコマンド**

`textlint --version` と `textlint --init` を実イメージ上で実行し、それぞれ `v15.7.1` の出力と `.textlintrc.json` の生成を確認した。

**lint**

`actionlint` の SC2086 は変更前後とも 12 件で増減なし（同一ディレクトリで stash を使って A/B 比較）。いずれも既存の `${GITHUB_WORKSPACE}` 参照に対する info レベルの指摘で、本 PR とは無関係。

## 本 PR に含まれないもの

修正を利用者に届けるには新しいリビジョンタグ（`2026c`）の publish が必要だが、リリース判断は本 PR とは分けてマージ後に行う。