### PR TITLE
test: lint fixtures in CI instead of only starting textlint

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,7 +56,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:alpine \
-            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'sh textlint/run-check.sh && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -86,7 +86,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:debian \
-            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'sh textlint/run-check.sh && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -116,7 +116,7 @@ jobs:
           
           docker run --rm -v ${GITHUB_WORKSPACE}/test-run:/workdir \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:debian-arm64 \
-            sh -c 'textlint --version && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
+            sh -c 'sh textlint/run-check.sh && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex';
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/tests/textlint/.textlintrc
+++ b/tests/textlint/.textlintrc
@@ -1,0 +1,16 @@
+{
+  "plugins": ["latex2e", "html"],
+  "filters": {
+    "comments": true
+  },
+  "rules": {
+    "preset-ja-technical-writing": {
+      "sentence-length": {
+        "max": 40
+      },
+      "ja-no-mixed-period": {
+        "periodMark": "。"
+      }
+    }
+  }
+}

--- a/tests/textlint/fixture.html
+++ b/tests/textlint/fixture.html
@@ -1,0 +1,14 @@
+<!-- Fixture for the CI lint check. The sentence below deliberately ends
+     without a period, so textlint must report
+     ja-technical-writing/ja-no-mixed-period for it. If nothing is reported,
+     the html plugin or the rule preset failed to load. -->
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>textlint fixture</title>
+  </head>
+  <body>
+    <p>この文は句点で終わっていない</p>
+  </body>
+</html>

--- a/tests/textlint/fixture.tex
+++ b/tests/textlint/fixture.tex
@@ -1,0 +1,8 @@
+% Fixture for the CI lint check. The sentence below is deliberately longer
+% than the sentence-length limit in .textlintrc, so textlint must report
+% ja-technical-writing/sentence-length for it. If nothing is reported, the
+% latex2e plugin or the rule preset failed to load.
+\documentclass{jsarticle}
+\begin{document}
+この文は検査のために意図的に長く書かれており、設定した一文あたりの最大文字数をはっきりと超えるようにしてある。
+\end{document}

--- a/tests/textlint/run-check.sh
+++ b/tests/textlint/run-check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Verify that the textlint bundled in the image actually works, not merely that
+# it starts. Each fixture carries a violation it is built to trigger, so a rule
+# that stops firing means its plugin or preset no longer resolves -- the class
+# of breakage a bare `textlint --version` cannot see.
+set -eu
+
+cd "$(dirname "$0")"
+
+expect_rule() {
+  file=$1
+  rule=$2
+
+  # textlint exits non-zero whenever it reports anything, which is the expected
+  # outcome here, so the run must not abort the script.
+  output=$(textlint -f json "$file" || true)
+
+  if ! printf '%s' "$output" | grep -q "$rule"; then
+    echo "FAIL: $file did not report $rule" >&2
+    echo "textlint output was:" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+
+  echo "ok: $file reported $rule"
+}
+
+expect_rule fixture.tex ja-technical-writing/sentence-length
+expect_rule fixture.html ja-technical-writing/ja-no-mixed-period
+
+echo "textlint check passed"


### PR DESCRIPTION
Resolves #106

## 背景

#105 で追加した `textlint --version` は、#104 のような PATH 由来の退行は捕まえられるが、確認できるのは**起動可否だけ**だった。ルールプリセットやプラグインの解決失敗は検出できない。textlint 15 への更新（#101）では、その確認をローカルで手動実施していた。

## 決定した方針

Issue に挙げた 3 つの決定事項を次のとおり確定した。

**1. lint 設定** — `tests/textlint/.textlintrc` にテスト専用の最小構成を置く。

利用側 3 者（`latex-environment` / `sotsuron-template` / `ise-report-template`）は設定が異なり、どれか一つを持ち込むと「そのテンプレートの文章規約」を本 repo が抱えることになる。ここで確かめたいのはプラグインとプリセットが解決されて動くことなので、その目的に絞る。

**2. テスト文書** — `tests/main.tex` は触らない。lint 専用の検体を別に用意する。

`main.tex` は `latexmk` のビルド検証用で、文章品質を満たすようには書かれていない。lint を通すために書き換えると検体としての性格が変わる。

**3. lint 失敗をビルド失敗とするか** — **する**。

違反ゼロの文書で成功を見るのではなく、**意図した違反が検出されること**を検査する設計にした。検出されない = ルールやプラグインが読み込めていない、を意味するのでビルドを止める理由になる。文章の書き方でリリースが止まることはない。

## 変更内容

```
tests/textlint/.textlintrc      プラグイン latex2e + html、filter comments、
                                preset-ja-technical-writing の最小構成
tests/textlint/fixture.tex      文字数上限を超える一文 → latex2e プラグイン経由
tests/textlint/fixture.html     句点で終わらない一文 → html プラグイン経由
tests/textlint/run-check.sh     期待するルール ID の報告を検査
```

`build-pr.yml` の 3 バリアントの呼び出しを差し替えた。

```diff
-sh -c 'textlint --version && latexmk -C main.tex && ...'
+sh -c 'sh textlint/run-check.sh && latexmk -C main.tex && ...'
```

検体ごとに**別のルール・別のプラグイン**を担当させ、1 回の実行で両プラグインとプリセットの解決を確認する。

| 検体 | プラグイン | 期待する検出 |
|---|---|---|
| `fixture.tex` | `textlint-plugin-latex2e` | `ja-technical-writing/sentence-length` |
| `fixture.html` | `textlint-plugin-html` | `ja-technical-writing/ja-no-mixed-period` |

## 検証

TeXLive のフルビルドは CI に任せ、ローカルでは公開済み `2026b-alpine` に main 相当の `ENV PATH` を重ねたイメージで実行した。

**正常系（CI と同一コマンドを通しで実行）**

```console
$ docker run --rm -v $PWD:/workdir <image> \
    sh -c 'sh textlint/run-check.sh && latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
ok: fixture.tex reported ja-technical-writing/sentence-length
ok: fixture.html reported ja-technical-writing/ja-no-mixed-period
textlint check passed
Latexmk: All targets (main.dvi main.pdf) are up-to-date
exit=0
```

`main.pdf`（64,173 bytes）の生成も確認済み。

**異常系 — 落ちないテストは意味がないため、退行を作って検出を確認した**

| シナリオ | 結果 |
|---|---|
| 検体を違反のない文に差し替え（ルール不発火） | exit 1 で検出 |
| プラグイン名を解決不能な名前に変更 | exit 1 で検出 |
| プリセット名を解決不能な名前に変更 | exit 1 で検出 |
| `textlint` が PATH に無い（#104 の退行） | exit 1 で検出 |

**lint**

- `actionlint`: SC2086 は変更前後とも 12 件で増減なし（同一ディレクトリで stash による A/B）。既存の `${GITHUB_WORKSPACE}` 参照に対する info 指摘
- `shellcheck tests/textlint/run-check.sh`: 指摘なし
- `.textlintrc`: 妥当な JSON であることを確認

## 補足

検体を `tests/textlint/` 配下に置いたのは、CI のテストステップが `cp -r tests/*` でコピーしており、**トップレベルのドットファイルは含まれない**ため。ディレクトリごとコピーされる位置なら `.textlintrc` も届く。実際に同じ手順でコピーして到達を確認した。

## 本 PR に含まれないもの

`2026c` の publish。alpine の PATH 修正（#105）と併せてリリース判断は別途行う。