### PR TITLE
docs: refresh current version references to 2026c

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ docker build -f alpine/Dockerfile -t texlive-ja-textlint:alpine .
 docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026b --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026c --push .
 ```
 
 ### Test Compilation
@@ -28,8 +28,8 @@ docker run --rm -v $(pwd)/tests:/workspace -w /workspace texlive-ja-textlint:alp
 ### Registry Operations
 ```bash
 # Push to registry (maintainers only)
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026b
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026c
 ```
 
 ## Image Structure
@@ -46,8 +46,8 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
 ## Version Management
 
 ### Current Tags
-- `2026b` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
-- `2026a` - Previous update
+- `2026c` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
+- `2026b` - Previous update
 - Multi-architecture: AMD64, ARM64
 
 ### Version Checking

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Supported tags / タグ一覧
 
 ### 推奨イメージ
-- [`latest`, `2026b`](./debian/Dockerfile)
+- [`latest`, `2026c`](./debian/Dockerfile)
   - お使いの環境に合わせて自動的に最適なイメージを選択
   - Intel Mac/Windows: 軽量・高速版
   - Apple Silicon Mac: 互換性重視版
 
 ### 個別指定イメージ
-- [`alpine`, `2026b-alpine`](./alpine/Dockerfile)
+- [`alpine`, `2026c-alpine`](./alpine/Dockerfile)
   - Intel Mac/Windows専用（軽量・高速）
   - Apple Silicon Macでは動作しません
-- [`debian`, `2026b-debian`](./debian/Dockerfile)
+- [`debian`, `2026c-debian`](./debian/Dockerfile)
   - すべての環境で動作（互換性重視）
 
 ## Install / インストール
@@ -25,9 +25,9 @@ GitHub Container Registry からインストールできます。
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026c
 
-# 最新版（2026bと同じ）
+# 最新版（2026cと同じ）
 docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 ```
 
@@ -35,7 +35,7 @@ docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026b \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026c \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 
 # latest タグでも同じ結果

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -29,7 +29,8 @@ that year (`2025`, `2025a`, ..., `2025i`, `2026a`, `2026b`, ...):
 - `2025` - Major TeXLive 2025 release
 - `2025a`-`2025i` - Successive updates during 2025
 - `2026a` - First release of 2026
-- `2026b` - Current stable release (also published as `latest`)
+- `2026b` - Successive update during 2026
+- `2026c` - Current stable release (also published as `latest`)
 
 See [README.md](../README.md) for the tags currently published on the registry.
 

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -16,7 +16,7 @@ docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 docker build -f alpine/Dockerfile -t my-texlive:latest .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026b --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026c --push .
 ```
 
 ### Running Containers
@@ -34,13 +34,13 @@ docker run --rm -v $(pwd)/my-thesis:/workspace -w /workspace texlive-ja-textlint
 ### Registry Operations
 ```bash
 # Tag for registry
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026c
 
 # Push to GitHub Container Registry
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026c
 
 # Pull from registry
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026b
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026c
 ```
 
 ## LaTeX Compilation Examples


### PR DESCRIPTION
## 背景

`2026c` をリリースするため、タグを切る前にドキュメントのタグ参照を更新する。

`2026b` 以降に入るのは次の 2 件。

| 変更 | 内容 |
|---|---|
| #105（`d246251`） | alpine の PATH 修正。`textlint` がコマンド名で起動できるようになる |
| #107 | CI の lint 検査強化。イメージの内容は変わらない |

つまり `2026c` は **alpine variant で `textlint` が使えるようになるリリース**。推奨タグは amd64 で alpine に解決されるため、Intel Mac / Windows の利用者はこれまでイメージから `textlint` を実行できなかった。

## 変更内容

- `README.md` — タグ一覧、`docker pull` / `docker run` の例
- `CLAUDE.md` — buildx / tag / push の例、Current Tags
- `docs/CLAUDE-EXAMPLES.md` — Registry Operations の例
- `docs/CLAUDE-DEVELOPMENT.md` — Calendar Versioning の一覧

`2026b` は削除せず「Successive update during 2026」として履歴に残した。`CLAUDE.md` の「Previous update」も `2026a` → `2026b` に繰り上げている。

## マージ順序

**PR #107 をマージした後に**マージする。`2026c` タグは両方を含む main に対して打つ。

## 補足

年号は**イメージのリリース年**であって TeX Live のバージョンではない（#96）。イメージが内包するのは引き続き TL2025 の凍結スナップショットで、TL2026 への移行判断とは独立している。