### PR TITLE
chore(renovate): follow the latex preset to the monday window

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
   "lockFileMaintenance": {
     "description": "The latex preset bumps direct npm dependencies but never refreshes the lock file, so advisories in transitive packages accumulate unseen. Regenerate the lock files on the same weekly cadence as the preset's other updates.",
     "enabled": true,
-    "schedule": ["after 9pm on sunday"]
+    "schedule": ["after 10:30am on monday"]
   }
 }


### PR DESCRIPTION
## 概要

`lockFileMaintenance.schedule` を `after 9pm on sunday` から `after 10:30am on monday` へ移動する。

このリポジトリの `lockFileMaintenance` は「preset の他の更新と同じ週次サイクルで lock ファイルを再生成する」ことを意図して schedule を明示している（設定内の description のとおり）。smkwlab/.github#112 で `latex` preset の実行窓が月曜午前へ移るため、同じ窓に揃える。

## 依存関係

smkwlab/.github#112（`latex` preset 側の変更）とセットで反映する。先にこちらだけ merge しても、preset 側が月曜に移るまでの間 lock 更新が月曜・その他が日曜という一時的なズレが出るだけで、実害はない。
