### PR TITLE
chore(renovate): follow the latex preset window to 11am

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
   "lockFileMaintenance": {
     "description": "The latex preset bumps direct npm dependencies but never refreshes the lock file, so advisories in transitive packages accumulate unseen. Regenerate the lock files on the same weekly cadence as the preset's other updates.",
     "enabled": true,
-    "schedule": ["after 10:30am on monday"]
+    "schedule": ["after 11am on monday"]
   }
 }


### PR DESCRIPTION
## 概要

`lockFileMaintenance.schedule` を `after 10:30am on monday` から `after 11am on monday` へ移動する。

このリポジトリの `lockFileMaintenance` は「preset の他の更新と同じ週次サイクルで lock ファイルを再生成する」意図で schedule を明示している（設定内の description のとおり）。smkwlab/.github#113 で `latex` preset の実行窓が 11:00 に移るため、同じ窓に揃える。

#113 の追随。
