### PR TITLE
chore(renovate): restore the sunday evening lock file window

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
   "lockFileMaintenance": {
     "description": "The latex preset bumps direct npm dependencies but never refreshes the lock file, so advisories in transitive packages accumulate unseen. Regenerate the lock files on the same weekly cadence as the preset's other updates.",
     "enabled": true,
-    "schedule": ["after 11am on monday"]
+    "schedule": ["after 9pm on sunday"]
   }
 }


### PR DESCRIPTION
## 概要

`lockFileMaintenance.schedule` を `after 11am on monday` から `after 9pm on sunday` へ戻す。

このリポジトリの `lockFileMaintenance` は「preset の他の更新と同じ週次サイクルで lock ファイルを再生成する」意図で schedule を明示している（設定内の description のとおり）。preset 側の窓が本来の日曜夜に戻るため追随させる。

smkwlab/.github#119 の追随。
