### PR TITLE
build(deps): upgrade the Japanese textlint rule presets

### DIFF
--- a/alpine/package-lock.json
+++ b/alpine/package-lock.json
@@ -10,9 +10,9 @@
         "textlint-filter-rule-comments": "^1.3.0",
         "textlint-plugin-html": "^1.0.1",
         "textlint-plugin-latex2e": "^1.2.1",
-        "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-        "textlint-rule-preset-ja-spacing": "^2.4.3",
-        "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+        "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
+        "textlint-rule-preset-ja-spacing": "^3.0.2",
+        "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "textlint-rule-terminology": "^5.2.16"
       }
     },
@@ -210,89 +210,19 @@
       }
     },
     "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-2.1.0.tgz",
-      "integrity": "sha512-Bi/mOIbCOeQMKGgk+hTR4Q8CASkDPi2IQkDaNDkvP3zdrlvHoKbosBu4tQ55bE8jPpT+Q78Km59ZVin5xiogxw==",
-      "license": "MIT",
-      "dependencies": {
-        "execall": "^1.0.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha512-/J0Q8CvOvlAdpvhfkD/WnTQ4H1eU0exze2nFGPj/RSC7jpQ0NkKe2r28T5eMkhEEs+fzepMZNy1kVRKNlC04nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-1.0.9.tgz",
-      "integrity": "sha512-uUZhMWs+4ZIXIDfmQcfKdSx17Yx/eGdEUSDs/0UCggzy1nGOi5GMNHo6sUV3NSjSx22vTySj1imsBaBZCyCWNA==",
-      "license": "MIT",
-      "dependencies": {
-        "sentence-splitter": "^3.0.11",
-        "textlint-rule-helper": "2.0.1"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/textlint-rule-helper": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.1.tgz",
-      "integrity": "sha512-QNGSOemLVxm1b0qnH5VpRY8uyHgfx/8M+St8wSy/d6mZh0abd+KAvhQSuO8cxmVeRKr/LRkhAB3+0QU5LKhLGw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-is": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-3.0.0.tgz",
+      "integrity": "sha512-2o9n4z49ntSPtJPlcJtxakyB4dAg2MKSvR9ZCZEHjye0ee27oWYzK6yHz2HjsXQqt9VeCwxNHDOIGIx2CQX0Dw==",
       "license": "MIT"
     },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-2.0.4.tgz",
+      "integrity": "sha512-g9Ge1xUV9xJy8T7nuutF/2J6Cg2mmPx4gKsC3dCdxVxuL0wMqOOnAi8l6psFpAQ5UFtQuAzwkdclrehPtBT5tg==",
       "license": "MIT",
       "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -625,25 +555,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.3.tgz",
-      "integrity": "sha512-fO/ORdOELvjbbeIfZfzrXFMhYHGofRGqd+am9zm3tZ4GlJINj/pA2eITyfd65Vg6+ZbHd/Cys7stpoRSWtQFdA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -752,12 +663,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
     },
     "node_modules/cacheable": {
       "version": "2.5.0",
@@ -869,20 +774,18 @@
       }
     },
     "node_modules/check-ends-with-period": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/check-ends-with-period/-/check-ends-with-period-1.0.1.tgz",
-      "integrity": "sha512-vhGWpphk52Q1CiU2YHpWhOOKyI1FMCVPfPO7X6M6fN60JbnzZCwnf9cgR+T4LDSZGCDd1mqzgCdIcffEFBrUFQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/check-ends-with-period/-/check-ends-with-period-3.0.2.tgz",
+      "integrity": "sha512-/Bw+avucqqZ7PjKCVDod1QDGyZjo7Ht2701pdgcpTXzK5jI73/OUh3VR+m18jNUoJx5DSOUv0AxELZF7FYtcDA==",
       "license": "MIT",
       "dependencies": {
-        "array.prototype.find": "^2.0.3",
-        "emoji-regex": "^6.4.1",
-        "end-with": "^1.0.2"
+        "emoji-regex": "^10.1.0"
       }
     },
     "node_modules/check-ends-with-period/node_modules/emoji-regex": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/clone-regexp": {
@@ -940,21 +843,6 @@
       "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
       "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -1121,12 +1009,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "node_modules/end-with": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/end-with/-/end-with-1.0.2.tgz",
-      "integrity": "sha512-DA7B8EjHnFqKjIj8bUkw+HCVAJza1++3rV88sCUQ8aCyf8gvtl6SgFAJy0JwrOotWyx5Cdfmo3GkRobcBpYYcQ==",
-      "license": "MIT"
-    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -1252,18 +1134,6 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "license": "MIT",
-      "dependencies": {
         "hasown": "^2.0.2"
       },
       "engines": {
@@ -1799,12 +1669,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -2217,15 +2081,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-symbol": {
@@ -2849,15 +2704,6 @@
         "object-assign": "^3.0.0"
       }
     },
-    "node_modules/moji/node_modules/object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/morpheme-match": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-2.0.4.tgz",
@@ -2924,11 +2770,14 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/object_values": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/object_values/-/object_values-0.1.2.tgz",
-      "integrity": "sha512-tZgUiKLraVH+4OAedBYrr4/K6KmAQw2RPNd1AuNdhLsuz5WP3VB7WuiKBWbOcjeqqAjus2ChIIWC8dSfmg7ReA==",
-      "license": "MIT"
+    "node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3227,20 +3076,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -3493,26 +3328,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -3568,38 +3383,20 @@
       }
     },
     "node_modules/sentence-splitter": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.3.tgz",
-      "integrity": "sha512-eDqaz4MasTn6Mp3dagKzIbiNsJpgpueMEQqCJeN9F9XQRFLDGFJ0kX8R3uMp+mU7J58dWjr4q6eks/nUX/vnJQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-5.0.1.tgz",
+      "integrity": "sha512-Eu9l95hQfI0WdhXTznuBzqsFjTuL6UnPq341Ro1s2bjE3DMoBuhE0wk4z+rwbwVXfOAeuOQM0UF30HR2+66VuQ==",
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "^4.4.2",
-        "concat-stream": "^2.0.0",
-        "object_values": "^0.1.2",
-        "structured-source": "^3.0.2"
-      },
-      "bin": {
-        "sentence-splitter": "bin/cmd.js"
+        "@textlint/ast-node-types": "^13.4.1",
+        "structured-source": "^4.0.0"
       }
     },
     "node_modules/sentence-splitter/node_modules/@textlint/ast-node-types": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz",
-      "integrity": "sha512-qi2jjgO6Tn3KNPGnm6B7p6QTEPvY95NFsIAaJuwbulur8iJUEenp1OnoUfiDaC/g2WPPEFkcfXpmnu8XEMFo2A==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
       "license": "MIT"
-    },
-    "node_modules/sentence-splitter/node_modules/boundary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
-      "integrity": "sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww=="
-    },
-    "node_modules/sentence-splitter/node_modules/structured-source": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
-      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
-      "dependencies": {
-        "boundary": "^1.0.1"
-      }
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -3804,15 +3601,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4149,9 +3937,9 @@
       }
     },
     "node_modules/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.4.3.tgz",
-      "integrity": "sha512-xIpEAgpaPTnavzCMLcSB/tlZ3Tq9paclyyMEgAQxkM9adv8TrwddZ+Ys+BSd4zjuVa94NED0bajYWtahSjZ53g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-3.0.2.tgz",
+      "integrity": "sha512-jeWjD7gwV1zzO/el0fHaLP5Hu9ihvCJp5yjisaKk5s4w7jgoDKcT0aqyP2HFZd99bOrFWea0GecCFvJt6/B8ew==",
       "license": "MIT",
       "dependencies": {
         "textlint-rule-helper": "^2.2.4"
@@ -4169,13 +3957,13 @@
       }
     },
     "node_modules/textlint-rule-ja-no-mixed-period": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-2.1.3.tgz",
-      "integrity": "sha512-O3TZlN1KebeQIQ3P2uQTq21DMqoB1ocAa916HM5y0bqs2Ym+/FP4w3XoFkrqD8sFovswxjv9yQxhELN5nbJXkg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-3.0.2.tgz",
+      "integrity": "sha512-/WHRvbAXPJxjDAmVYjIp5qBHPS7Uqv3H+fH0oGMWzujEV4n2URtXmxqTUv7nd4giTRqeV2yuMZWYRRgA9Mh0Sg==",
       "license": "MIT",
       "dependencies": {
-        "check-ends-with-period": "^1.0.1",
-        "textlint-rule-helper": "^2.2.3"
+        "check-ends-with-period": "^3.0.2",
+        "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-no-redundant-expression": {
@@ -4193,22 +3981,29 @@
       }
     },
     "node_modules/textlint-rule-ja-no-space-around-parentheses": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.4.2.tgz",
-      "integrity": "sha512-DmmWEKu2hFJs/C4Ruxm/Zkp5gc9W+8kTgUULx54J00MJyJgLWm0XY9BH3OdN66+4+3BFutvxzCLU9y/M1+Dx7w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-3.0.2.tgz",
+      "integrity": "sha512-/G1MNHo65kIhFFD+2/0CIZ5HuKa+GXkpHkUr3EREa2HQP52rzP8L6cwYfl+gtlEKZ8iCQMfN0SbPulodALVErw==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-no-space-around-slash": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-slash/-/textlint-rule-ja-no-space-around-slash-3.0.2.tgz",
+      "integrity": "sha512-OdgDIh1AXxv8idIsWI6pN8xwTal+1Zb4033XKqxq7sZ7clk3CNqC5p+BUORUNMA/KeloYUo6o1lSGWPePmD+GQ==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-no-space-between-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.4.2.tgz",
-      "integrity": "sha512-yDiZrJYX2cVO85tLw+ojUntky44ijEfIX2sWinIEN0IdYMCINjYwmgRYFmnqwQ+MZyo+foAt2vLUZtaSZlk/Lw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-3.0.2.tgz",
+      "integrity": "sha512-fQ1z01IgrG4HCuZUZ2YZiOXdBA4hQE92gbe+SXXKGjOYD+99mVq0nmqdjjRY3HPSy7IAcqlefKdK9DQ32FH85A==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "regx": "^1.0.4",
         "textlint-rule-helper": "^2.2.4"
       }
@@ -4235,53 +4030,66 @@
       }
     },
     "node_modules/textlint-rule-ja-space-after-exclamation": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.4.2.tgz",
-      "integrity": "sha512-3qH0aIG48MrA8qhcljGSGxPmvrrmOQsP/kTfj8SGDKdkBUs05z1x1bgw106RVNVv1enz2v+ZafuVdgFViRKWfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-3.0.2.tgz",
+      "integrity": "sha512-EiKXAD43vNVR7sWlCP1+QvMJQYSDpwxXodLOFHKWEYnUJACTm/54YBb8943oMhDbdWXPOVaBzU6XtX5lmBkIrw==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-after-question": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.4.2.tgz",
-      "integrity": "sha512-ie1R03y1606QApXu+ZF6X+bAJLccRy/lA5JityfTO9M4EM+7ENMle9fTMoEEKJkNkjHaLi530IzqAZ+CLEe8Qw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-3.0.2.tgz",
+      "integrity": "sha512-t3aTXVX1ma/3V8E6G2mwkrHoLfu/3bTV4l6p6yySfOdb2wNiahmD08Cy71sD20CHzHxk57Ocx2OXFKKJx+9s2A==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-code": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.4.2.tgz",
-      "integrity": "sha512-DM4OF7seafTKrxPFjUJyxx/lwlg8CO3wgwmTJWhQ+6po3mQVV6QaBHpc0861/32kUAJm1ZgRpiBlDWUdraXFFA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-3.0.2.tgz",
+      "integrity": "sha512-n9q9IBRie6ck3Bkapj+XMUT+lDD8lx0jH7YjIrDTzNRdIE76COF3NycMyhZm/o1i7tyQMggGarCmNaK1xcUKWg==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-emphasis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-emphasis/-/textlint-rule-ja-space-around-emphasis-3.0.2.tgz",
+      "integrity": "sha512-Oxut/HrzeamAaCw9Ll1vnYTi5YOKfWwL+dgnVeRKkJkDGIvpPgIer510HaovNHHAv2d3FzEkW3PxPKva4N3WUA==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-link": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-2.4.2.tgz",
-      "integrity": "sha512-++o4wwCnDiubgE60QuOv0xW/0EcF2ta4EfjOycYsLYqvJ6DzFEZFGv3S/TujzmrIdRc8sHAO62489flvPu1DsQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-3.0.2.tgz",
+      "integrity": "sha512-lh+7girFo0gt706/0bT3Yyf+QHdAnyaC8ybidbDN+NlDfkFi31qPdiFPrdTlQXwD9FfZelwBGAHVFAz22eoG4g==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-strong": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-strong/-/textlint-rule-ja-space-around-strong-3.0.2.tgz",
+      "integrity": "sha512-uKxjaikPv8BuznFS7kPu8eqPGtOTiSpKw2+P8vf+bNbN2FzJq4RHXDjhhj2R5rUmIPPFgAcurDHPZ/A1WE66HQ==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-between-half-and-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.4.2.tgz",
-      "integrity": "sha512-GqwSy0ivm4Q5Bok9LaOwfg+H1auLRMoMi2aY/7aSIrgvX/RD5aZ2Rk2lm3TTX42mR1UrQu8GDqktUEZfvQ913w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-3.0.2.tgz",
+      "integrity": "sha512-wdX0fCy7K7IBfxcflnEbkgx0j4mNQ7XRPGP7DFMHxJhqigZBkbrV/+uu2UwoBMxHd5CDJrPdxllrcrfNZoe4Ew==",
       "license": "MIT",
       "dependencies": {
         "@textlint/regexp-string-matcher": "^2.0.2",
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
@@ -4309,14 +4117,13 @@
       }
     },
     "node_modules/textlint-rule-max-comma": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-max-comma/-/textlint-rule-max-comma-2.0.2.tgz",
-      "integrity": "sha512-t4twAgEZWWMhIYH3xURZr/A1EcAUKiC10/N0EU6RG+ZBa9+FB5HDhMdQMS5wHqEI1FopWHTYYv/sC2PGEtvyLg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-comma/-/textlint-rule-max-comma-4.0.0.tgz",
+      "integrity": "sha512-2vKKXNg1YuTqr9/FrHvOGEHFe+6lNSDtzuEv+KRB+tuaj++UNa/YPvyY34UdDYuHUSKNcYdto8GlIUhAJDW9WQ==",
       "license": "MIT",
       "dependencies": {
-        "sentence-splitter": "^3.2.1",
-        "textlint-util-to-string": "^3.1.1",
-        "unist-util-filter": "^2.0.3"
+        "sentence-splitter": "^5.0.0",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-max-kanji-continuous-len": {
@@ -4330,15 +4137,15 @@
       }
     },
     "node_modules/textlint-rule-max-ten": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-4.0.4.tgz",
-      "integrity": "sha512-7jH04Ey2HrjVWrjPB4Epk+X8ngeWcWDbvxhRji6sVu2mKuy8O/rjl4oMKFfHeOJuvnKjP+sfg9/o2nO6Jp0ggw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-5.0.0.tgz",
+      "integrity": "sha512-EWOvbEa3Ukxz0+GAUEJ91DYFSC3IkyJ10dBcsU6VlL33k1BvTRoFr3m26w6upnXJffXQUI70Etn39I++2duyhA==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.0",
-        "textlint-rule-helper": "^2.3.0",
-        "textlint-util-to-string": "^3.3.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-double-negative-ja": {
@@ -4351,39 +4158,38 @@
       }
     },
     "node_modules/textlint-rule-no-doubled-conjunction": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-2.0.4.tgz",
-      "integrity": "sha512-GUpZgJoEYk1EsqoE+0bcdln8ZbH6UDK9TWld3E2II+lGMw/0ALkoTNXhAsNK1ST/M7zYEX6a5qOCN68t2grDaA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-3.0.1.tgz",
+      "integrity": "sha512-fRJEiy0rkrmUDVdgzGiUKAgGngziUfsjL4eqY4a3YfFxXwtczOP+hyHfvLNrHOUI58Y6lNoLZpa5lNNXbzFyNg==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.2",
-        "textlint-rule-helper": "^2.2.1",
-        "textlint-util-to-string": "^3.1.1"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/textlint-rule-no-doubled-conjunctive-particle-ga": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-2.0.5.tgz",
-      "integrity": "sha512-/rakdhxPqo/enKykNkP7m/dyZX6QUAI6mXmWk8S3mg2mTkwRC69zT/5hLk723nsb/iuV1lbI90aD3ZeVvpTEsA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-3.0.0.tgz",
+      "integrity": "sha512-4IowX2YlTlD9VifThZwpENRh918BpPNTks0i4bOL7Gn82jUiXK0EZuV8Jtksm7i+RYG1xsO0U7P9AnxmuSxeDg==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.1",
-        "textlint-rule-helper": "^2.2.0",
-        "textlint-util-to-string": "^3.1.1"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-doubled-joshi": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-4.1.0.tgz",
-      "integrity": "sha512-u+MNVNXn1RvX2RwY6uE+Qg5a4zWEskz8dwBNHNzPXT+D0UIkWAMBHvTXH8GqZHdxJCO0ke8+Wa+Gpbxz0PSTBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-5.1.1.tgz",
+      "integrity": "sha512-bxiuqZiHE9ZZGHDX+O6J4vzhre7ghb7NBkPi/5TAWVvnQLULgY3COx/KXJgFItPmSrpYF8/AT/uTHC4QOg59qw==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.1",
-        "textlint-rule-helper": "^2.3.0",
-        "textlint-util-to-string": "^3.3.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-dropping-the-ra": {
@@ -4408,68 +4214,33 @@
       }
     },
     "node_modules/textlint-rule-no-hankaku-kana": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-hankaku-kana/-/textlint-rule-no-hankaku-kana-1.0.2.tgz",
-      "integrity": "sha512-3wcCi2zz68+0Lzc+2a3A0JIkj0CRW02GrwP12KDOi+k6ouJ4E9C1qP09wb0CJCIJeSctcXuWmaNNgo+HC7lWRQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-hankaku-kana/-/textlint-rule-no-hankaku-kana-2.0.1.tgz",
+      "integrity": "sha512-39s94HK6V1xnII1haYiYQnWy1YQAKK7Zj0mcpUMFHHC4M5JdsRnhGs6DQPVEff0gQIFV0iuDNlofXt15kjMtEA==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
-        "textlint-rule-helper": "^1.1.5"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "license": "MIT"
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "textlint-rule-helper": "^2.3.0",
+        "textlint-tester": "^13.3.1"
       }
     },
     "node_modules/textlint-rule-no-mix-dearu-desumasu": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-5.0.0.tgz",
-      "integrity": "sha512-fBNWXBUeP9xuxZYjNqm3PQDsHStYPxpkJaLwTvbNQEZ6rpC1dHsHwLujYtuAQVuvrfxxU6J4jtepP61rhjPA8g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-6.0.4.tgz",
+      "integrity": "sha512-SmALtOFbtmJ//k2iLMvtqhGrgJ/6uDVZFK7TBj2npVAbt10VxgLL87K+62pQ/BqiN9DpOVObshVFdug7lUOKHw==",
       "license": "MIT",
       "dependencies": {
-        "analyze-desumasu-dearu": "^5.0.0",
-        "textlint-rule-helper": "^2.0.0",
-        "unist-util-visit": "^3.0.0"
+        "analyze-desumasu-dearu": "^5.0.2",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/textlint-rule-no-nfd": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.2.tgz",
-      "integrity": "sha512-n6tUx40/V6koDo78qqePHxSovuwSIKO0xwY3FCqVDbcfg9GxQCjde1twQJ99T3bs4LabhPOo/Pt3USaQ9XcTRQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-2.0.2.tgz",
+      "integrity": "sha512-lIUvcQ+wqtConpPQU2YwEJl2dRcRyyrxPYZ3V76UwnkVg++XPLIrE5mLDgyNE/UIQ34e/KitJfMLqKWvnkFbNQ==",
       "license": "MIT",
       "dependencies": {
         "match-index": "^1.0.3",
-        "textlint-rule-helper": "^2.1.1",
-        "unorm": "^1.4.1"
+        "textlint-rule-helper": "^2.3.0"
       }
     },
     "node_modules/textlint-rule-no-zero-width-spaces": {
@@ -4483,76 +4254,76 @@
       }
     },
     "node_modules/textlint-rule-preset-ja-spacing": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.4.3.tgz",
-      "integrity": "sha512-WAiWY9TOE8/bRdl14XJdjkPQcV0hLS4O+PCUYU1yxXmJhZ8V3ciw2GYqpA9GL73qAxL25UD6mkf1yfz6aJ4qSA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-3.0.2.tgz",
+      "integrity": "sha512-6uFVfqSBHjexMfTLO2jq/QOczSgYuPRVPgOsTrh60RItQiznk2oHAKL5rLdn0STty3fxqTx+6cFnkjqw4VaEkA==",
       "license": "MIT",
       "dependencies": {
-        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.4.3",
-        "textlint-rule-ja-no-space-around-parentheses": "^2.4.2",
-        "textlint-rule-ja-no-space-between-full-width": "^2.4.2",
-        "textlint-rule-ja-space-after-exclamation": "^2.4.2",
-        "textlint-rule-ja-space-after-question": "^2.4.2",
-        "textlint-rule-ja-space-around-code": "^2.4.2",
-        "textlint-rule-ja-space-around-link": "^2.4.2",
-        "textlint-rule-ja-space-between-half-and-full-width": "^2.4.2"
+        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^3.0.2",
+        "textlint-rule-ja-no-space-around-parentheses": "^3.0.2",
+        "textlint-rule-ja-no-space-around-slash": "^3.0.2",
+        "textlint-rule-ja-no-space-between-full-width": "^3.0.2",
+        "textlint-rule-ja-space-after-exclamation": "^3.0.2",
+        "textlint-rule-ja-space-after-question": "^3.0.2",
+        "textlint-rule-ja-space-around-code": "^3.0.2",
+        "textlint-rule-ja-space-around-emphasis": "^3.0.2",
+        "textlint-rule-ja-space-around-link": "^3.0.2",
+        "textlint-rule-ja-space-around-strong": "^3.0.2",
+        "textlint-rule-ja-space-between-half-and-full-width": "^3.0.2"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-7.0.0.tgz",
-      "integrity": "sha512-zzpMctCALdCOOfz/Gci0dgsb4Vi6sjAkxzNoruMEqMRjZyzp6CdRCi1ofe/ZusTzU5aGw452xCAg0VAD7tZeHA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-12.0.2.tgz",
+      "integrity": "sha512-BBVY6oA5V799k5wRfP+gCpDHsp6vWjWX2UT+/KLlAFFsNdmRB8Z6qyOnqiOjfzmLGIRgoMcPI1dXj5upOqnD6Q==",
       "license": "MIT",
       "dependencies": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": "^2.0.0",
-        "@textlint-rule/textlint-rule-no-unmatched-pair": "^1.0.8",
-        "@textlint/module-interop": "^12.0.0",
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^3.0.0",
+        "@textlint-rule/textlint-rule-no-unmatched-pair": "^2.0.4",
+        "@textlint/module-interop": "^14.4.0",
         "textlint-rule-ja-no-abusage": "^3.0.0",
-        "textlint-rule-ja-no-mixed-period": "^2.1.1",
-        "textlint-rule-ja-no-redundant-expression": "^4.0.0",
-        "textlint-rule-ja-no-successive-word": "^2.0.0",
+        "textlint-rule-ja-no-mixed-period": "^3.0.1",
+        "textlint-rule-ja-no-redundant-expression": "^4.0.1",
+        "textlint-rule-ja-no-successive-word": "^2.0.1",
         "textlint-rule-ja-no-weak-phrase": "^2.0.0",
         "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-        "textlint-rule-max-comma": "^2.0.2",
+        "textlint-rule-max-comma": "^4.0.0",
         "textlint-rule-max-kanji-continuous-len": "^1.1.1",
-        "textlint-rule-max-ten": "^4.0.2",
-        "textlint-rule-no-double-negative-ja": "^2.0.0",
-        "textlint-rule-no-doubled-conjunction": "^2.0.1",
-        "textlint-rule-no-doubled-conjunctive-particle-ga": "^2.0.1",
-        "textlint-rule-no-doubled-joshi": "^4.0.0",
+        "textlint-rule-max-ten": "^5.0.0",
+        "textlint-rule-no-double-negative-ja": "^2.0.1",
+        "textlint-rule-no-doubled-conjunction": "^3.0.0",
+        "textlint-rule-no-doubled-conjunctive-particle-ga": "^3.0.0",
+        "textlint-rule-no-doubled-joshi": "^5.1.0",
         "textlint-rule-no-dropping-the-ra": "^3.0.0",
         "textlint-rule-no-exclamation-question-mark": "^1.1.0",
-        "textlint-rule-no-hankaku-kana": "^1.0.2",
-        "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-        "textlint-rule-no-nfd": "^1.0.2",
+        "textlint-rule-no-hankaku-kana": "^2.0.1",
+        "textlint-rule-no-mix-dearu-desumasu": "^6.0.3",
+        "textlint-rule-no-nfd": "^2.0.2",
         "textlint-rule-no-zero-width-spaces": "^1.0.1",
-        "textlint-rule-preset-jtf-style": "^2.3.12",
-        "textlint-rule-sentence-length": "^3.0.0"
+        "textlint-rule-preset-jtf-style": "^3.0.1",
+        "textlint-rule-sentence-length": "^5.2.0"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing/node_modules/@textlint/module-interop": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.6.1.tgz",
-      "integrity": "sha512-COyRctLVh2ktAObmht3aNtqUvP0quoellKu1c2RrXny1po+Mf7PkvEKIxphtArE4JXMAmu01cDxfH6X88+eYIg==",
+      "version": "14.8.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-14.8.4.tgz",
+      "integrity": "sha512-1LdPYLAVpa27NOt6EqvuFO99s4XLB0c19Hw9xKSG6xQ1K82nUEyuWhzTQKb3KJ5Qx7qj14JlXZLfnEuL6A16Bw==",
       "license": "MIT"
     },
     "node_modules/textlint-rule-preset-jtf-style": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-2.3.14.tgz",
-      "integrity": "sha512-xkVclRrC921eejsDP79dt7UhwT15825etgQSQx8SvOqaPRNwDdQ7kzep4LIyrdLgPm/3k/gX8qyw0BrN02U27w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-3.0.3.tgz",
+      "integrity": "sha512-NTvqjg3oMTGjSDoH6MnYu+DDWW6cEghA66Lb8N0bheTphAj99aaG10HGhwTfDbaH2P6NfPQvRP5ISxiXCT9zdg==",
       "license": "MIT",
       "dependencies": {
         "analyze-desumasu-dearu": "^2.1.2",
         "japanese-numerals-to-number": "^1.0.2",
         "match-index": "^1.0.3",
         "moji": "^0.5.1",
-        "regexp.prototype.flags": "^1.4.3",
+        "regexp.prototype.flags": "^1.5.3",
         "regx": "^1.0.4",
-        "textlint-rule-helper": "^2.2.1",
-        "textlint-rule-prh": "^5.2.1"
-      },
-      "peerDependencies": {
-        "textlint": ">= 5.6.0"
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-rule-prh": "^6.0.0"
       }
     },
     "node_modules/textlint-rule-preset-jtf-style/node_modules/analyze-desumasu-dearu": {
@@ -4560,6 +4331,17 @@
       "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
       "integrity": "sha512-4YPL7IRAuaZflE10+BVhKr6k5KQl/DiLeNCIF7ISqKr0ogM2hqm9ztRNCPqL/xYDI7hfuIHR8T+U7mIDRLQNXw==",
       "license": "MIT"
+    },
+    "node_modules/textlint-rule-preset-jtf-style/node_modules/textlint-rule-prh": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-6.1.0.tgz",
+      "integrity": "sha512-KrchADHw1/LZ/tAQ2XwL/XdUhunKCvlNmwgp+6hdyzuWX7uojOkDdJWWV0KAN4XWsK6Te5w/SZcYwQ7X6i3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "prh": "^5.4.4",
+        "textlint-rule-helper": "^2.3.1"
+      }
     },
     "node_modules/textlint-rule-prh": {
       "version": "5.3.0",
@@ -4574,15 +4356,27 @@
       }
     },
     "node_modules/textlint-rule-sentence-length": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-3.0.1.tgz",
-      "integrity": "sha512-Les3CmXziuUJW8MP6VrWvsCpm+MrVhU7RR2vOJHCteXprlF1ifwUMnjMI6++HD4Ac+2XWNo0KOdgfyRTff9FmA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-5.2.1.tgz",
+      "integrity": "sha512-z4HylabPy+e1I5DcuzDmcT65hvyytTlsD+uM49JkCBTSJBWqzQQ3kCGk4b1cF+kANS2HifWNnpTG/jfSOeavIw==",
       "license": "MIT",
       "dependencies": {
-        "@textlint/regexp-string-matcher": "^1.1.0",
-        "sentence-splitter": "^3.2.3",
-        "textlint-rule-helper": "^2.1.1",
-        "textlint-util-to-string": "^3.1.1"
+        "@textlint/regexp-string-matcher": "^2.0.2",
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
+      }
+    },
+    "node_modules/textlint-rule-sentence-length/node_modules/@textlint/regexp-string-matcher": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
+      "integrity": "sha512-OXLD9XRxMhd3S0LWuPHpiARQOI7z9tCOs0FsynccW2lmyZzHHFJ9/eR6kuK9xF459Qf+740qI5h+/0cx+NljzA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0"
       }
     },
     "node_modules/textlint-rule-terminology": {
@@ -4597,6 +4391,136 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/textlint-tester": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-13.4.1.tgz",
+      "integrity": "sha512-Ubm9kUZ/NyY0Ggo1RkW2o5QSx6EJ/ogMT1kD5b5pk4cdFTWpUSs8StDMROgcz29wPhvS6sY/35qYALzqyZh8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/feature-flag": "^13.4.1",
+        "@textlint/kernel": "^13.4.1",
+        "@textlint/textlint-plugin-markdown": "^13.4.1",
+        "@textlint/textlint-plugin-text": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-node-types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "license": "MIT"
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-tester": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-13.4.1.tgz",
+      "integrity": "sha512-YSHUR1qDgMPGF5+nvrquEhif6zRJ667xUnfP/9rTNtThIhoTQINvczr5/7xa43F1PDWplL6Curw+2jrE1qHwGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-traverse": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-13.4.1.tgz",
+      "integrity": "sha512-uucuC7+NHWkXx2TX5vuyreuHeb+GFiA83V65I+FnYP5EC4dAMOQ86rTSPrZmCwLz+qIWgfDgihGzPccpj3EZGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/feature-flag": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-13.4.1.tgz",
+      "integrity": "sha512-qY8gKUf30XtzWMTkwYeKytCo6KPx6milpz8YZhuRsEPjT/5iNdakJp5USWDQWDrwbQf7RbRncQdU+LX5JbM9YA==",
+      "license": "MIT"
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/kernel": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-13.4.1.tgz",
+      "integrity": "sha512-r2sUhjPysFjl2Ax37x9AfWkJM8jgKN0bL4SX3xRzOukdcj69Dst5On5qBZtULaVMX1LDkwkdxA6ZEADmq27qQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "@textlint/ast-tester": "^13.4.1",
+        "@textlint/ast-traverse": "^13.4.1",
+        "@textlint/feature-flag": "^13.4.1",
+        "@textlint/source-code-fixer": "^13.4.1",
+        "@textlint/types": "^13.4.1",
+        "@textlint/utils": "^13.4.1",
+        "debug": "^4.3.4",
+        "fast-equals": "^4.0.3",
+        "structured-source": "^4.0.0"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/markdown-to-ast": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-13.4.1.tgz",
+      "integrity": "sha512-jUa5bTNmxjEgfCXW4xfn7eSJqzUXyNKiIDWLKtI4MUKRNhT3adEaa/NuQl0Mii3Hu3HraZR7hYhRHLh+eeM43w==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "debug": "^4.3.4",
+        "mdast-util-gfm-autolink-literal": "^0.1.3",
+        "remark-footnotes": "^3.0.0",
+        "remark-frontmatter": "^3.0.0",
+        "remark-gfm": "^1.0.0",
+        "remark-parse": "^9.0.0",
+        "traverse": "^0.6.7",
+        "unified": "^9.2.2"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/source-code-fixer": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-13.4.1.tgz",
+      "integrity": "sha512-Sl29f3Tpimp0uVE3ysyJBjxaFTVYLOXiJX14eWCQ/kC5ZhIXGosEbStzkP1n8Urso1rs1W4p/2UemVAm3NH2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/types": "^13.4.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/text-to-ast": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-13.4.1.tgz",
+      "integrity": "sha512-vCA7uMmbjRv06sEHPbwxTV5iS8OQedC5s7qwmXnWAn2LLWxg4Yp98mONPS1o4D5cPomzYyKNCSfbLwu6yJBUQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/textlint-plugin-markdown": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-13.4.1.tgz",
+      "integrity": "sha512-OcLkFKYmbYeGJ0kj2487qcicCYTiE2vJLwfPcUDJrNoMYak5JtvHJfWffck8gON2mEM00DPkHH0UdxZpFjDfeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/markdown-to-ast": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/textlint-plugin-text": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-13.4.1.tgz",
+      "integrity": "sha512-z0p5B8WUfTCIRmhjVHFfJv719oIElDDKWOIZei4CyYkfMGo0kq8fkrYBkUR6VZ6gofHwc+mwmIABdUf1rDHzYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/text-to-ast": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-1ApwQa31sFmiJeJ5yTNFqjbb2D1ICZvIDW0tFSM0OtmQCSDFNcKD3YrrwDBgSokZ6gWQq/FpNjlhi6iETUWt0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/utils": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-13.4.1.tgz",
+      "integrity": "sha512-wX8RT1ejHAPTDmqlzngf0zI5kYoe3QvGDcj+skoTxSv+m/wOs/NyEr92d+ahCP32YqFYzXlqU7aDx2FkULKT+g==",
+      "license": "MIT"
     },
     "node_modules/textlint-util-to-string": {
       "version": "3.3.4",
@@ -4808,6 +4732,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
+      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
+      "license": "MIT",
+      "dependencies": {
+        "gopd": "^1.2.0",
+        "typedarray.prototype.slice": "^1.0.5",
+        "which-typed-array": "^1.1.18"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -4916,11 +4857,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+    "node_modules/typedarray.prototype.slice": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
+      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "math-intrinsics": "^1.1.0",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -5023,15 +4980,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-filter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-2.0.3.tgz",
-      "integrity": "sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^4.0.0"
-      }
-    },
     "node_modules/unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
@@ -5055,21 +5003,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-visit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
-      "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unist-util-visit-parents": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
@@ -5084,42 +5017,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-visit/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
-      "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "license": "MIT or GPL-2.0",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/untildify": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
@@ -5128,12 +5025,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/alpine/package.json
+++ b/alpine/package.json
@@ -5,9 +5,9 @@
     "textlint-filter-rule-comments": "^1.3.0",
     "textlint-plugin-html": "^1.0.1",
     "textlint-plugin-latex2e": "^1.2.1",
-    "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-    "textlint-rule-preset-ja-spacing": "^2.4.3",
-    "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+    "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
+    "textlint-rule-preset-ja-spacing": "^3.0.2",
+    "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "textlint-rule-terminology": "^5.2.16"
   }
 }

--- a/debian/package-lock.json
+++ b/debian/package-lock.json
@@ -10,9 +10,9 @@
         "textlint-filter-rule-comments": "^1.3.0",
         "textlint-plugin-html": "^1.0.1",
         "textlint-plugin-latex2e": "^1.2.1",
-        "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-        "textlint-rule-preset-ja-spacing": "^2.4.3",
-        "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+        "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
+        "textlint-rule-preset-ja-spacing": "^3.0.2",
+        "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "textlint-rule-terminology": "^5.2.16"
       }
     },
@@ -210,89 +210,19 @@
       }
     },
     "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-2.1.0.tgz",
-      "integrity": "sha512-Bi/mOIbCOeQMKGgk+hTR4Q8CASkDPi2IQkDaNDkvP3zdrlvHoKbosBu4tQ55bE8jPpT+Q78Km59ZVin5xiogxw==",
-      "license": "MIT",
-      "dependencies": {
-        "execall": "^1.0.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha512-/J0Q8CvOvlAdpvhfkD/WnTQ4H1eU0exze2nFGPj/RSC7jpQ0NkKe2r28T5eMkhEEs+fzepMZNy1kVRKNlC04nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-invalid-control-character/node_modules/is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-1.0.9.tgz",
-      "integrity": "sha512-uUZhMWs+4ZIXIDfmQcfKdSx17Yx/eGdEUSDs/0UCggzy1nGOi5GMNHo6sUV3NSjSx22vTySj1imsBaBZCyCWNA==",
-      "license": "MIT",
-      "dependencies": {
-        "sentence-splitter": "^3.0.11",
-        "textlint-rule-helper": "2.0.1"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/textlint-rule-helper": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.1.tgz",
-      "integrity": "sha512-QNGSOemLVxm1b0qnH5VpRY8uyHgfx/8M+St8wSy/d6mZh0abd+KAvhQSuO8cxmVeRKr/LRkhAB3+0QU5LKhLGw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-is": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-3.0.0.tgz",
+      "integrity": "sha512-2o9n4z49ntSPtJPlcJtxakyB4dAg2MKSvR9ZCZEHjye0ee27oWYzK6yHz2HjsXQqt9VeCwxNHDOIGIx2CQX0Dw==",
       "license": "MIT"
     },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-2.0.4.tgz",
+      "integrity": "sha512-g9Ge1xUV9xJy8T7nuutF/2J6Cg2mmPx4gKsC3dCdxVxuL0wMqOOnAi8l6psFpAQ5UFtQuAzwkdclrehPtBT5tg==",
       "license": "MIT",
       "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/@textlint-rule/textlint-rule-no-unmatched-pair/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -625,25 +555,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.3.tgz",
-      "integrity": "sha512-fO/ORdOELvjbbeIfZfzrXFMhYHGofRGqd+am9zm3tZ4GlJINj/pA2eITyfd65Vg6+ZbHd/Cys7stpoRSWtQFdA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -752,12 +663,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
     },
     "node_modules/cacheable": {
       "version": "2.5.0",
@@ -869,20 +774,18 @@
       }
     },
     "node_modules/check-ends-with-period": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/check-ends-with-period/-/check-ends-with-period-1.0.1.tgz",
-      "integrity": "sha512-vhGWpphk52Q1CiU2YHpWhOOKyI1FMCVPfPO7X6M6fN60JbnzZCwnf9cgR+T4LDSZGCDd1mqzgCdIcffEFBrUFQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/check-ends-with-period/-/check-ends-with-period-3.0.2.tgz",
+      "integrity": "sha512-/Bw+avucqqZ7PjKCVDod1QDGyZjo7Ht2701pdgcpTXzK5jI73/OUh3VR+m18jNUoJx5DSOUv0AxELZF7FYtcDA==",
       "license": "MIT",
       "dependencies": {
-        "array.prototype.find": "^2.0.3",
-        "emoji-regex": "^6.4.1",
-        "end-with": "^1.0.2"
+        "emoji-regex": "^10.1.0"
       }
     },
     "node_modules/check-ends-with-period/node_modules/emoji-regex": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/clone-regexp": {
@@ -940,21 +843,6 @@
       "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
       "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -1121,12 +1009,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "node_modules/end-with": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/end-with/-/end-with-1.0.2.tgz",
-      "integrity": "sha512-DA7B8EjHnFqKjIj8bUkw+HCVAJza1++3rV88sCUQ8aCyf8gvtl6SgFAJy0JwrOotWyx5Cdfmo3GkRobcBpYYcQ==",
-      "license": "MIT"
-    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -1252,18 +1134,6 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "license": "MIT",
-      "dependencies": {
         "hasown": "^2.0.2"
       },
       "engines": {
@@ -1799,12 +1669,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -2217,15 +2081,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-symbol": {
@@ -2849,15 +2704,6 @@
         "object-assign": "^3.0.0"
       }
     },
-    "node_modules/moji/node_modules/object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/morpheme-match": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-2.0.4.tgz",
@@ -2924,11 +2770,14 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/object_values": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/object_values/-/object_values-0.1.2.tgz",
-      "integrity": "sha512-tZgUiKLraVH+4OAedBYrr4/K6KmAQw2RPNd1AuNdhLsuz5WP3VB7WuiKBWbOcjeqqAjus2ChIIWC8dSfmg7ReA==",
-      "license": "MIT"
+    "node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3227,20 +3076,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -3493,26 +3328,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -3568,38 +3383,20 @@
       }
     },
     "node_modules/sentence-splitter": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.3.tgz",
-      "integrity": "sha512-eDqaz4MasTn6Mp3dagKzIbiNsJpgpueMEQqCJeN9F9XQRFLDGFJ0kX8R3uMp+mU7J58dWjr4q6eks/nUX/vnJQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-5.0.1.tgz",
+      "integrity": "sha512-Eu9l95hQfI0WdhXTznuBzqsFjTuL6UnPq341Ro1s2bjE3DMoBuhE0wk4z+rwbwVXfOAeuOQM0UF30HR2+66VuQ==",
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "^4.4.2",
-        "concat-stream": "^2.0.0",
-        "object_values": "^0.1.2",
-        "structured-source": "^3.0.2"
-      },
-      "bin": {
-        "sentence-splitter": "bin/cmd.js"
+        "@textlint/ast-node-types": "^13.4.1",
+        "structured-source": "^4.0.0"
       }
     },
     "node_modules/sentence-splitter/node_modules/@textlint/ast-node-types": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.3.tgz",
-      "integrity": "sha512-qi2jjgO6Tn3KNPGnm6B7p6QTEPvY95NFsIAaJuwbulur8iJUEenp1OnoUfiDaC/g2WPPEFkcfXpmnu8XEMFo2A==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
       "license": "MIT"
-    },
-    "node_modules/sentence-splitter/node_modules/boundary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
-      "integrity": "sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww=="
-    },
-    "node_modules/sentence-splitter/node_modules/structured-source": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
-      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
-      "dependencies": {
-        "boundary": "^1.0.1"
-      }
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -3804,15 +3601,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4149,9 +3937,9 @@
       }
     },
     "node_modules/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.4.3.tgz",
-      "integrity": "sha512-xIpEAgpaPTnavzCMLcSB/tlZ3Tq9paclyyMEgAQxkM9adv8TrwddZ+Ys+BSd4zjuVa94NED0bajYWtahSjZ53g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-3.0.2.tgz",
+      "integrity": "sha512-jeWjD7gwV1zzO/el0fHaLP5Hu9ihvCJp5yjisaKk5s4w7jgoDKcT0aqyP2HFZd99bOrFWea0GecCFvJt6/B8ew==",
       "license": "MIT",
       "dependencies": {
         "textlint-rule-helper": "^2.2.4"
@@ -4169,13 +3957,13 @@
       }
     },
     "node_modules/textlint-rule-ja-no-mixed-period": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-2.1.3.tgz",
-      "integrity": "sha512-O3TZlN1KebeQIQ3P2uQTq21DMqoB1ocAa916HM5y0bqs2Ym+/FP4w3XoFkrqD8sFovswxjv9yQxhELN5nbJXkg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-3.0.2.tgz",
+      "integrity": "sha512-/WHRvbAXPJxjDAmVYjIp5qBHPS7Uqv3H+fH0oGMWzujEV4n2URtXmxqTUv7nd4giTRqeV2yuMZWYRRgA9Mh0Sg==",
       "license": "MIT",
       "dependencies": {
-        "check-ends-with-period": "^1.0.1",
-        "textlint-rule-helper": "^2.2.3"
+        "check-ends-with-period": "^3.0.2",
+        "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-no-redundant-expression": {
@@ -4193,22 +3981,29 @@
       }
     },
     "node_modules/textlint-rule-ja-no-space-around-parentheses": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.4.2.tgz",
-      "integrity": "sha512-DmmWEKu2hFJs/C4Ruxm/Zkp5gc9W+8kTgUULx54J00MJyJgLWm0XY9BH3OdN66+4+3BFutvxzCLU9y/M1+Dx7w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-3.0.2.tgz",
+      "integrity": "sha512-/G1MNHo65kIhFFD+2/0CIZ5HuKa+GXkpHkUr3EREa2HQP52rzP8L6cwYfl+gtlEKZ8iCQMfN0SbPulodALVErw==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-no-space-around-slash": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-around-slash/-/textlint-rule-ja-no-space-around-slash-3.0.2.tgz",
+      "integrity": "sha512-OdgDIh1AXxv8idIsWI6pN8xwTal+1Zb4033XKqxq7sZ7clk3CNqC5p+BUORUNMA/KeloYUo6o1lSGWPePmD+GQ==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-no-space-between-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.4.2.tgz",
-      "integrity": "sha512-yDiZrJYX2cVO85tLw+ojUntky44ijEfIX2sWinIEN0IdYMCINjYwmgRYFmnqwQ+MZyo+foAt2vLUZtaSZlk/Lw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-3.0.2.tgz",
+      "integrity": "sha512-fQ1z01IgrG4HCuZUZ2YZiOXdBA4hQE92gbe+SXXKGjOYD+99mVq0nmqdjjRY3HPSy7IAcqlefKdK9DQ32FH85A==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "regx": "^1.0.4",
         "textlint-rule-helper": "^2.2.4"
       }
@@ -4235,53 +4030,66 @@
       }
     },
     "node_modules/textlint-rule-ja-space-after-exclamation": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.4.2.tgz",
-      "integrity": "sha512-3qH0aIG48MrA8qhcljGSGxPmvrrmOQsP/kTfj8SGDKdkBUs05z1x1bgw106RVNVv1enz2v+ZafuVdgFViRKWfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-3.0.2.tgz",
+      "integrity": "sha512-EiKXAD43vNVR7sWlCP1+QvMJQYSDpwxXodLOFHKWEYnUJACTm/54YBb8943oMhDbdWXPOVaBzU6XtX5lmBkIrw==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.3",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-after-question": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.4.2.tgz",
-      "integrity": "sha512-ie1R03y1606QApXu+ZF6X+bAJLccRy/lA5JityfTO9M4EM+7ENMle9fTMoEEKJkNkjHaLi530IzqAZ+CLEe8Qw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-3.0.2.tgz",
+      "integrity": "sha512-t3aTXVX1ma/3V8E6G2mwkrHoLfu/3bTV4l6p6yySfOdb2wNiahmD08Cy71sD20CHzHxk57Ocx2OXFKKJx+9s2A==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-code": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.4.2.tgz",
-      "integrity": "sha512-DM4OF7seafTKrxPFjUJyxx/lwlg8CO3wgwmTJWhQ+6po3mQVV6QaBHpc0861/32kUAJm1ZgRpiBlDWUdraXFFA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-3.0.2.tgz",
+      "integrity": "sha512-n9q9IBRie6ck3Bkapj+XMUT+lDD8lx0jH7YjIrDTzNRdIE76COF3NycMyhZm/o1i7tyQMggGarCmNaK1xcUKWg==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-emphasis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-emphasis/-/textlint-rule-ja-space-around-emphasis-3.0.2.tgz",
+      "integrity": "sha512-Oxut/HrzeamAaCw9Ll1vnYTi5YOKfWwL+dgnVeRKkJkDGIvpPgIer510HaovNHHAv2d3FzEkW3PxPKva4N3WUA==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-around-link": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-2.4.2.tgz",
-      "integrity": "sha512-++o4wwCnDiubgE60QuOv0xW/0EcF2ta4EfjOycYsLYqvJ6DzFEZFGv3S/TujzmrIdRc8sHAO62489flvPu1DsQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-link/-/textlint-rule-ja-space-around-link-3.0.2.tgz",
+      "integrity": "sha512-lh+7girFo0gt706/0bT3Yyf+QHdAnyaC8ybidbDN+NlDfkFi31qPdiFPrdTlQXwD9FfZelwBGAHVFAz22eoG4g==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
+        "textlint-rule-helper": "^2.2.4"
+      }
+    },
+    "node_modules/textlint-rule-ja-space-around-strong": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-around-strong/-/textlint-rule-ja-space-around-strong-3.0.2.tgz",
+      "integrity": "sha512-uKxjaikPv8BuznFS7kPu8eqPGtOTiSpKw2+P8vf+bNbN2FzJq4RHXDjhhj2R5rUmIPPFgAcurDHPZ/A1WE66HQ==",
+      "license": "MIT",
+      "dependencies": {
         "textlint-rule-helper": "^2.2.4"
       }
     },
     "node_modules/textlint-rule-ja-space-between-half-and-full-width": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.4.2.tgz",
-      "integrity": "sha512-GqwSy0ivm4Q5Bok9LaOwfg+H1auLRMoMi2aY/7aSIrgvX/RD5aZ2Rk2lm3TTX42mR1UrQu8GDqktUEZfvQ913w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-3.0.2.tgz",
+      "integrity": "sha512-wdX0fCy7K7IBfxcflnEbkgx0j4mNQ7XRPGP7DFMHxJhqigZBkbrV/+uu2UwoBMxHd5CDJrPdxllrcrfNZoe4Ew==",
       "license": "MIT",
       "dependencies": {
         "@textlint/regexp-string-matcher": "^2.0.2",
-        "match-index": "^1.0.1",
         "textlint-rule-helper": "^2.2.4"
       }
     },
@@ -4309,14 +4117,13 @@
       }
     },
     "node_modules/textlint-rule-max-comma": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-max-comma/-/textlint-rule-max-comma-2.0.2.tgz",
-      "integrity": "sha512-t4twAgEZWWMhIYH3xURZr/A1EcAUKiC10/N0EU6RG+ZBa9+FB5HDhMdQMS5wHqEI1FopWHTYYv/sC2PGEtvyLg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-comma/-/textlint-rule-max-comma-4.0.0.tgz",
+      "integrity": "sha512-2vKKXNg1YuTqr9/FrHvOGEHFe+6lNSDtzuEv+KRB+tuaj++UNa/YPvyY34UdDYuHUSKNcYdto8GlIUhAJDW9WQ==",
       "license": "MIT",
       "dependencies": {
-        "sentence-splitter": "^3.2.1",
-        "textlint-util-to-string": "^3.1.1",
-        "unist-util-filter": "^2.0.3"
+        "sentence-splitter": "^5.0.0",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-max-kanji-continuous-len": {
@@ -4330,15 +4137,15 @@
       }
     },
     "node_modules/textlint-rule-max-ten": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-4.0.4.tgz",
-      "integrity": "sha512-7jH04Ey2HrjVWrjPB4Epk+X8ngeWcWDbvxhRji6sVu2mKuy8O/rjl4oMKFfHeOJuvnKjP+sfg9/o2nO6Jp0ggw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-5.0.0.tgz",
+      "integrity": "sha512-EWOvbEa3Ukxz0+GAUEJ91DYFSC3IkyJ10dBcsU6VlL33k1BvTRoFr3m26w6upnXJffXQUI70Etn39I++2duyhA==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.0",
-        "textlint-rule-helper": "^2.3.0",
-        "textlint-util-to-string": "^3.3.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-double-negative-ja": {
@@ -4351,39 +4158,38 @@
       }
     },
     "node_modules/textlint-rule-no-doubled-conjunction": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-2.0.4.tgz",
-      "integrity": "sha512-GUpZgJoEYk1EsqoE+0bcdln8ZbH6UDK9TWld3E2II+lGMw/0ALkoTNXhAsNK1ST/M7zYEX6a5qOCN68t2grDaA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-3.0.1.tgz",
+      "integrity": "sha512-fRJEiy0rkrmUDVdgzGiUKAgGngziUfsjL4eqY4a3YfFxXwtczOP+hyHfvLNrHOUI58Y6lNoLZpa5lNNXbzFyNg==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.2",
-        "textlint-rule-helper": "^2.2.1",
-        "textlint-util-to-string": "^3.1.1"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/textlint-rule-no-doubled-conjunctive-particle-ga": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-2.0.5.tgz",
-      "integrity": "sha512-/rakdhxPqo/enKykNkP7m/dyZX6QUAI6mXmWk8S3mg2mTkwRC69zT/5hLk723nsb/iuV1lbI90aD3ZeVvpTEsA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-3.0.0.tgz",
+      "integrity": "sha512-4IowX2YlTlD9VifThZwpENRh918BpPNTks0i4bOL7Gn82jUiXK0EZuV8Jtksm7i+RYG1xsO0U7P9AnxmuSxeDg==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.1",
-        "textlint-rule-helper": "^2.2.0",
-        "textlint-util-to-string": "^3.1.1"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-doubled-joshi": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-4.1.0.tgz",
-      "integrity": "sha512-u+MNVNXn1RvX2RwY6uE+Qg5a4zWEskz8dwBNHNzPXT+D0UIkWAMBHvTXH8GqZHdxJCO0ke8+Wa+Gpbxz0PSTBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-5.1.1.tgz",
+      "integrity": "sha512-bxiuqZiHE9ZZGHDX+O6J4vzhre7ghb7NBkPi/5TAWVvnQLULgY3COx/KXJgFItPmSrpYF8/AT/uTHC4QOg59qw==",
       "license": "MIT",
       "dependencies": {
         "kuromojin": "^3.0.0",
-        "sentence-splitter": "^3.2.1",
-        "textlint-rule-helper": "^2.3.0",
-        "textlint-util-to-string": "^3.3.0"
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
       }
     },
     "node_modules/textlint-rule-no-dropping-the-ra": {
@@ -4408,68 +4214,33 @@
       }
     },
     "node_modules/textlint-rule-no-hankaku-kana": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-hankaku-kana/-/textlint-rule-no-hankaku-kana-1.0.2.tgz",
-      "integrity": "sha512-3wcCi2zz68+0Lzc+2a3A0JIkj0CRW02GrwP12KDOi+k6ouJ4E9C1qP09wb0CJCIJeSctcXuWmaNNgo+HC7lWRQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-hankaku-kana/-/textlint-rule-no-hankaku-kana-2.0.1.tgz",
+      "integrity": "sha512-39s94HK6V1xnII1haYiYQnWy1YQAKK7Zj0mcpUMFHHC4M5JdsRnhGs6DQPVEff0gQIFV0iuDNlofXt15kjMtEA==",
       "license": "MIT",
       "dependencies": {
-        "match-index": "^1.0.1",
-        "textlint-rule-helper": "^1.1.5"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "license": "MIT"
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-rule-no-hankaku-kana/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "textlint-rule-helper": "^2.3.0",
+        "textlint-tester": "^13.3.1"
       }
     },
     "node_modules/textlint-rule-no-mix-dearu-desumasu": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-5.0.0.tgz",
-      "integrity": "sha512-fBNWXBUeP9xuxZYjNqm3PQDsHStYPxpkJaLwTvbNQEZ6rpC1dHsHwLujYtuAQVuvrfxxU6J4jtepP61rhjPA8g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-6.0.4.tgz",
+      "integrity": "sha512-SmALtOFbtmJ//k2iLMvtqhGrgJ/6uDVZFK7TBj2npVAbt10VxgLL87K+62pQ/BqiN9DpOVObshVFdug7lUOKHw==",
       "license": "MIT",
       "dependencies": {
-        "analyze-desumasu-dearu": "^5.0.0",
-        "textlint-rule-helper": "^2.0.0",
-        "unist-util-visit": "^3.0.0"
+        "analyze-desumasu-dearu": "^5.0.2",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "node_modules/textlint-rule-no-nfd": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.2.tgz",
-      "integrity": "sha512-n6tUx40/V6koDo78qqePHxSovuwSIKO0xwY3FCqVDbcfg9GxQCjde1twQJ99T3bs4LabhPOo/Pt3USaQ9XcTRQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-2.0.2.tgz",
+      "integrity": "sha512-lIUvcQ+wqtConpPQU2YwEJl2dRcRyyrxPYZ3V76UwnkVg++XPLIrE5mLDgyNE/UIQ34e/KitJfMLqKWvnkFbNQ==",
       "license": "MIT",
       "dependencies": {
         "match-index": "^1.0.3",
-        "textlint-rule-helper": "^2.1.1",
-        "unorm": "^1.4.1"
+        "textlint-rule-helper": "^2.3.0"
       }
     },
     "node_modules/textlint-rule-no-zero-width-spaces": {
@@ -4483,76 +4254,76 @@
       }
     },
     "node_modules/textlint-rule-preset-ja-spacing": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.4.3.tgz",
-      "integrity": "sha512-WAiWY9TOE8/bRdl14XJdjkPQcV0hLS4O+PCUYU1yxXmJhZ8V3ciw2GYqpA9GL73qAxL25UD6mkf1yfz6aJ4qSA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-3.0.2.tgz",
+      "integrity": "sha512-6uFVfqSBHjexMfTLO2jq/QOczSgYuPRVPgOsTrh60RItQiznk2oHAKL5rLdn0STty3fxqTx+6cFnkjqw4VaEkA==",
       "license": "MIT",
       "dependencies": {
-        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.4.3",
-        "textlint-rule-ja-no-space-around-parentheses": "^2.4.2",
-        "textlint-rule-ja-no-space-between-full-width": "^2.4.2",
-        "textlint-rule-ja-space-after-exclamation": "^2.4.2",
-        "textlint-rule-ja-space-after-question": "^2.4.2",
-        "textlint-rule-ja-space-around-code": "^2.4.2",
-        "textlint-rule-ja-space-around-link": "^2.4.2",
-        "textlint-rule-ja-space-between-half-and-full-width": "^2.4.2"
+        "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^3.0.2",
+        "textlint-rule-ja-no-space-around-parentheses": "^3.0.2",
+        "textlint-rule-ja-no-space-around-slash": "^3.0.2",
+        "textlint-rule-ja-no-space-between-full-width": "^3.0.2",
+        "textlint-rule-ja-space-after-exclamation": "^3.0.2",
+        "textlint-rule-ja-space-after-question": "^3.0.2",
+        "textlint-rule-ja-space-around-code": "^3.0.2",
+        "textlint-rule-ja-space-around-emphasis": "^3.0.2",
+        "textlint-rule-ja-space-around-link": "^3.0.2",
+        "textlint-rule-ja-space-around-strong": "^3.0.2",
+        "textlint-rule-ja-space-between-half-and-full-width": "^3.0.2"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-7.0.0.tgz",
-      "integrity": "sha512-zzpMctCALdCOOfz/Gci0dgsb4Vi6sjAkxzNoruMEqMRjZyzp6CdRCi1ofe/ZusTzU5aGw452xCAg0VAD7tZeHA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ja-technical-writing/-/textlint-rule-preset-ja-technical-writing-12.0.2.tgz",
+      "integrity": "sha512-BBVY6oA5V799k5wRfP+gCpDHsp6vWjWX2UT+/KLlAFFsNdmRB8Z6qyOnqiOjfzmLGIRgoMcPI1dXj5upOqnD6Q==",
       "license": "MIT",
       "dependencies": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": "^2.0.0",
-        "@textlint-rule/textlint-rule-no-unmatched-pair": "^1.0.8",
-        "@textlint/module-interop": "^12.0.0",
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^3.0.0",
+        "@textlint-rule/textlint-rule-no-unmatched-pair": "^2.0.4",
+        "@textlint/module-interop": "^14.4.0",
         "textlint-rule-ja-no-abusage": "^3.0.0",
-        "textlint-rule-ja-no-mixed-period": "^2.1.1",
-        "textlint-rule-ja-no-redundant-expression": "^4.0.0",
-        "textlint-rule-ja-no-successive-word": "^2.0.0",
+        "textlint-rule-ja-no-mixed-period": "^3.0.1",
+        "textlint-rule-ja-no-redundant-expression": "^4.0.1",
+        "textlint-rule-ja-no-successive-word": "^2.0.1",
         "textlint-rule-ja-no-weak-phrase": "^2.0.0",
         "textlint-rule-ja-unnatural-alphabet": "2.0.1",
-        "textlint-rule-max-comma": "^2.0.2",
+        "textlint-rule-max-comma": "^4.0.0",
         "textlint-rule-max-kanji-continuous-len": "^1.1.1",
-        "textlint-rule-max-ten": "^4.0.2",
-        "textlint-rule-no-double-negative-ja": "^2.0.0",
-        "textlint-rule-no-doubled-conjunction": "^2.0.1",
-        "textlint-rule-no-doubled-conjunctive-particle-ga": "^2.0.1",
-        "textlint-rule-no-doubled-joshi": "^4.0.0",
+        "textlint-rule-max-ten": "^5.0.0",
+        "textlint-rule-no-double-negative-ja": "^2.0.1",
+        "textlint-rule-no-doubled-conjunction": "^3.0.0",
+        "textlint-rule-no-doubled-conjunctive-particle-ga": "^3.0.0",
+        "textlint-rule-no-doubled-joshi": "^5.1.0",
         "textlint-rule-no-dropping-the-ra": "^3.0.0",
         "textlint-rule-no-exclamation-question-mark": "^1.1.0",
-        "textlint-rule-no-hankaku-kana": "^1.0.2",
-        "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-        "textlint-rule-no-nfd": "^1.0.2",
+        "textlint-rule-no-hankaku-kana": "^2.0.1",
+        "textlint-rule-no-mix-dearu-desumasu": "^6.0.3",
+        "textlint-rule-no-nfd": "^2.0.2",
         "textlint-rule-no-zero-width-spaces": "^1.0.1",
-        "textlint-rule-preset-jtf-style": "^2.3.12",
-        "textlint-rule-sentence-length": "^3.0.0"
+        "textlint-rule-preset-jtf-style": "^3.0.1",
+        "textlint-rule-sentence-length": "^5.2.0"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing/node_modules/@textlint/module-interop": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.6.1.tgz",
-      "integrity": "sha512-COyRctLVh2ktAObmht3aNtqUvP0quoellKu1c2RrXny1po+Mf7PkvEKIxphtArE4JXMAmu01cDxfH6X88+eYIg==",
+      "version": "14.8.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-14.8.4.tgz",
+      "integrity": "sha512-1LdPYLAVpa27NOt6EqvuFO99s4XLB0c19Hw9xKSG6xQ1K82nUEyuWhzTQKb3KJ5Qx7qj14JlXZLfnEuL6A16Bw==",
       "license": "MIT"
     },
     "node_modules/textlint-rule-preset-jtf-style": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-2.3.14.tgz",
-      "integrity": "sha512-xkVclRrC921eejsDP79dt7UhwT15825etgQSQx8SvOqaPRNwDdQ7kzep4LIyrdLgPm/3k/gX8qyw0BrN02U27w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-3.0.3.tgz",
+      "integrity": "sha512-NTvqjg3oMTGjSDoH6MnYu+DDWW6cEghA66Lb8N0bheTphAj99aaG10HGhwTfDbaH2P6NfPQvRP5ISxiXCT9zdg==",
       "license": "MIT",
       "dependencies": {
         "analyze-desumasu-dearu": "^2.1.2",
         "japanese-numerals-to-number": "^1.0.2",
         "match-index": "^1.0.3",
         "moji": "^0.5.1",
-        "regexp.prototype.flags": "^1.4.3",
+        "regexp.prototype.flags": "^1.5.3",
         "regx": "^1.0.4",
-        "textlint-rule-helper": "^2.2.1",
-        "textlint-rule-prh": "^5.2.1"
-      },
-      "peerDependencies": {
-        "textlint": ">= 5.6.0"
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-rule-prh": "^6.0.0"
       }
     },
     "node_modules/textlint-rule-preset-jtf-style/node_modules/analyze-desumasu-dearu": {
@@ -4560,6 +4331,17 @@
       "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
       "integrity": "sha512-4YPL7IRAuaZflE10+BVhKr6k5KQl/DiLeNCIF7ISqKr0ogM2hqm9ztRNCPqL/xYDI7hfuIHR8T+U7mIDRLQNXw==",
       "license": "MIT"
+    },
+    "node_modules/textlint-rule-preset-jtf-style/node_modules/textlint-rule-prh": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-6.1.0.tgz",
+      "integrity": "sha512-KrchADHw1/LZ/tAQ2XwL/XdUhunKCvlNmwgp+6hdyzuWX7uojOkDdJWWV0KAN4XWsK6Te5w/SZcYwQ7X6i3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "prh": "^5.4.4",
+        "textlint-rule-helper": "^2.3.1"
+      }
     },
     "node_modules/textlint-rule-prh": {
       "version": "5.3.0",
@@ -4574,15 +4356,27 @@
       }
     },
     "node_modules/textlint-rule-sentence-length": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-3.0.1.tgz",
-      "integrity": "sha512-Les3CmXziuUJW8MP6VrWvsCpm+MrVhU7RR2vOJHCteXprlF1ifwUMnjMI6++HD4Ac+2XWNo0KOdgfyRTff9FmA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-5.2.1.tgz",
+      "integrity": "sha512-z4HylabPy+e1I5DcuzDmcT65hvyytTlsD+uM49JkCBTSJBWqzQQ3kCGk4b1cF+kANS2HifWNnpTG/jfSOeavIw==",
       "license": "MIT",
       "dependencies": {
-        "@textlint/regexp-string-matcher": "^1.1.0",
-        "sentence-splitter": "^3.2.3",
-        "textlint-rule-helper": "^2.1.1",
-        "textlint-util-to-string": "^3.1.1"
+        "@textlint/regexp-string-matcher": "^2.0.2",
+        "sentence-splitter": "^5.0.0",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-util-to-string": "^3.3.4"
+      }
+    },
+    "node_modules/textlint-rule-sentence-length/node_modules/@textlint/regexp-string-matcher": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
+      "integrity": "sha512-OXLD9XRxMhd3S0LWuPHpiARQOI7z9tCOs0FsynccW2lmyZzHHFJ9/eR6kuK9xF459Qf+740qI5h+/0cx+NljzA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0"
       }
     },
     "node_modules/textlint-rule-terminology": {
@@ -4597,6 +4391,136 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/textlint-tester": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-13.4.1.tgz",
+      "integrity": "sha512-Ubm9kUZ/NyY0Ggo1RkW2o5QSx6EJ/ogMT1kD5b5pk4cdFTWpUSs8StDMROgcz29wPhvS6sY/35qYALzqyZh8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/feature-flag": "^13.4.1",
+        "@textlint/kernel": "^13.4.1",
+        "@textlint/textlint-plugin-markdown": "^13.4.1",
+        "@textlint/textlint-plugin-text": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-node-types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
+      "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "license": "MIT"
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-tester": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-13.4.1.tgz",
+      "integrity": "sha512-YSHUR1qDgMPGF5+nvrquEhif6zRJ667xUnfP/9rTNtThIhoTQINvczr5/7xa43F1PDWplL6Curw+2jrE1qHwGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/ast-traverse": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-13.4.1.tgz",
+      "integrity": "sha512-uucuC7+NHWkXx2TX5vuyreuHeb+GFiA83V65I+FnYP5EC4dAMOQ86rTSPrZmCwLz+qIWgfDgihGzPccpj3EZGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/feature-flag": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-13.4.1.tgz",
+      "integrity": "sha512-qY8gKUf30XtzWMTkwYeKytCo6KPx6milpz8YZhuRsEPjT/5iNdakJp5USWDQWDrwbQf7RbRncQdU+LX5JbM9YA==",
+      "license": "MIT"
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/kernel": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-13.4.1.tgz",
+      "integrity": "sha512-r2sUhjPysFjl2Ax37x9AfWkJM8jgKN0bL4SX3xRzOukdcj69Dst5On5qBZtULaVMX1LDkwkdxA6ZEADmq27qQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "@textlint/ast-tester": "^13.4.1",
+        "@textlint/ast-traverse": "^13.4.1",
+        "@textlint/feature-flag": "^13.4.1",
+        "@textlint/source-code-fixer": "^13.4.1",
+        "@textlint/types": "^13.4.1",
+        "@textlint/utils": "^13.4.1",
+        "debug": "^4.3.4",
+        "fast-equals": "^4.0.3",
+        "structured-source": "^4.0.0"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/markdown-to-ast": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-13.4.1.tgz",
+      "integrity": "sha512-jUa5bTNmxjEgfCXW4xfn7eSJqzUXyNKiIDWLKtI4MUKRNhT3adEaa/NuQl0Mii3Hu3HraZR7hYhRHLh+eeM43w==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1",
+        "debug": "^4.3.4",
+        "mdast-util-gfm-autolink-literal": "^0.1.3",
+        "remark-footnotes": "^3.0.0",
+        "remark-frontmatter": "^3.0.0",
+        "remark-gfm": "^1.0.0",
+        "remark-parse": "^9.0.0",
+        "traverse": "^0.6.7",
+        "unified": "^9.2.2"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/source-code-fixer": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-13.4.1.tgz",
+      "integrity": "sha512-Sl29f3Tpimp0uVE3ysyJBjxaFTVYLOXiJX14eWCQ/kC5ZhIXGosEbStzkP1n8Urso1rs1W4p/2UemVAm3NH2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/types": "^13.4.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/text-to-ast": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-13.4.1.tgz",
+      "integrity": "sha512-vCA7uMmbjRv06sEHPbwxTV5iS8OQedC5s7qwmXnWAn2LLWxg4Yp98mONPS1o4D5cPomzYyKNCSfbLwu6yJBUQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/textlint-plugin-markdown": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-13.4.1.tgz",
+      "integrity": "sha512-OcLkFKYmbYeGJ0kj2487qcicCYTiE2vJLwfPcUDJrNoMYak5JtvHJfWffck8gON2mEM00DPkHH0UdxZpFjDfeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/markdown-to-ast": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/textlint-plugin-text": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-13.4.1.tgz",
+      "integrity": "sha512-z0p5B8WUfTCIRmhjVHFfJv719oIElDDKWOIZei4CyYkfMGo0kq8fkrYBkUR6VZ6gofHwc+mwmIABdUf1rDHzYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/text-to-ast": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/types": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-13.4.1.tgz",
+      "integrity": "sha512-1ApwQa31sFmiJeJ5yTNFqjbb2D1ICZvIDW0tFSM0OtmQCSDFNcKD3YrrwDBgSokZ6gWQq/FpNjlhi6iETUWt0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^13.4.1"
+      }
+    },
+    "node_modules/textlint-tester/node_modules/@textlint/utils": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-13.4.1.tgz",
+      "integrity": "sha512-wX8RT1ejHAPTDmqlzngf0zI5kYoe3QvGDcj+skoTxSv+m/wOs/NyEr92d+ahCP32YqFYzXlqU7aDx2FkULKT+g==",
+      "license": "MIT"
     },
     "node_modules/textlint-util-to-string": {
       "version": "3.3.4",
@@ -4808,6 +4732,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
+      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
+      "license": "MIT",
+      "dependencies": {
+        "gopd": "^1.2.0",
+        "typedarray.prototype.slice": "^1.0.5",
+        "which-typed-array": "^1.1.18"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -4916,11 +4857,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+    "node_modules/typedarray.prototype.slice": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
+      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "math-intrinsics": "^1.1.0",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -5023,15 +4980,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-filter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-2.0.3.tgz",
-      "integrity": "sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^4.0.0"
-      }
-    },
     "node_modules/unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
@@ -5055,21 +5003,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-visit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
-      "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0",
-        "unist-util-visit-parents": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unist-util-visit-parents": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
@@ -5084,42 +5017,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-visit/node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
-      "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "license": "MIT or GPL-2.0",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/untildify": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
@@ -5128,12 +5025,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/debian/package.json
+++ b/debian/package.json
@@ -5,9 +5,9 @@
     "textlint-filter-rule-comments": "^1.3.0",
     "textlint-plugin-html": "^1.0.1",
     "textlint-plugin-latex2e": "^1.2.1",
-    "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
-    "textlint-rule-preset-ja-spacing": "^2.4.3",
-    "textlint-rule-preset-ja-technical-writing": "^7.0.0",
+    "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
+    "textlint-rule-preset-ja-spacing": "^3.0.2",
+    "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "textlint-rule-terminology": "^5.2.16"
   }
 }


### PR DESCRIPTION
## 概要

日本語校正プリセットの major 更新を 1 本にまとめる。Renovate が出している #118 / #119 / #120 を代替する。

| パッケージ | 変更前 | 変更後 | 対応する Renovate PR |
|---|---|---|---|
| `textlint-rule-no-mix-dearu-desumasu` | `^5.0.0` | `^6.0.4` | #118 |
| `textlint-rule-preset-ja-spacing` | `^2.3.0` | `^3.0.2` | #119 |
| `textlint-rule-preset-ja-technical-writing` | `^7.0.0` | `^12.0.2` | #120 |

## なぜ 1 本にまとめるのか

**#118 と #120 は実質 1 つの変更**である。`preset-ja-technical-writing` の依存が major をまたいで変わる。

| preset の版 | 要求する `no-mix-dearu-desumasu` |
|---|---|
| v7（現行） | `^5.0.0` |
| v12 | `^6.0.3` |

片方だけ merge すると、イメージが 5.x と 6.x の両方を抱えることになる。`.textlintrc` が直接名指しする `no-mix-dearu-desumasu` と、preset が内部で参照するものが別バージョンになり、挙動が食い違う余地が生まれる。

`preset-ja-spacing`（#119）は独立している（依存は `ja-space-*` 系のみ）。ただし Docker イメージのビルドが重いため、ビルドサイクルを 1 回で済ませる目的で同梱した。

## 検証

新しい lock ファイルからローカルに `npm ci` し、CI と同じ `tests/textlint/run-check.sh` を実行した。

```
textlint                                       15.8.0
textlint-rule-no-mix-dearu-desumasu            6.0.4
textlint-rule-preset-ja-spacing                3.0.2
textlint-rule-preset-ja-technical-writing      12.0.2

ok: fixture.tex reported ja-technical-writing/sentence-length
ok: fixture.html reported ja-technical-writing/ja-no-mixed-period
textlint check passed
```

major をまたいでもルール ID が変わっていないこと（fixture が意図どおり違反を出し続けること）を確認済み。

## 挙動の変化

`tests/main.tex` を新旧で比較すると、指摘が 1 件増える。

| | 現行 (preset v7) | 新版 (preset v12) |
|---|---|---|
| `ja-technical-writing/sentence-length` | 5 | 5 |
| `ja-technical-writing/no-mix-dearu-desumasu` | 0 | **1** |

```
line 83: "ですます"調 であるべき箇所に、次の "である"調 の箇所があります: "である。"
```

`no-mix-dearu-desumasu` の検出が効くようになった分。ルールとしては従来から意図されていたものなので、そのまま取り込む。学生の原稿でも同種の新規指摘が出うる。

## 影響範囲

イメージ利用側（latex-environment 経由の各テンプレート・学生リポジトリ）は、次回のイメージタグ更新時にこの変更を受け取る。配布は手動のタグ push なので、本 PR の merge だけでは学生には届かない。

`ise-report-template` の devcontainer は独立管理で、既に同じバージョンへ更新済み（smkwlab/ise-report-template#99）。

## 後始末

merge 後、#118 / #119 / #120 は手動で close する。
