### PR TITLE
ci(deps): move the action majors onto the Node 24 runtime

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build Docker image
         uses: ./.github/actions/build/
         with:
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build Docker image
         uses: ./.github/actions/build/
         with:
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build Docker image
         uses: ./.github/actions/build/
         with:

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -72,9 +72,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -110,7 +110,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-debian-amd64 \
             ghcr.io/${{ github.repository_owner }}/texlive-ja-textlint:${{ github.ref_name }}-debian-arm64
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         continue-on-error: true
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/update-readme-issue.yml
+++ b/.github/workflows/update-readme-issue.yml
@@ -22,7 +22,7 @@ jobs:
           echo "name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Create Issue
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const tagName = '${{ steps.tag.outputs.name }}';


### PR DESCRIPTION
## 概要

GitHub Actions の major 更新 4 本を 1 本にまとめる。Renovate が出している #121 / #122 / #123 / #124 を代替する。

| アクション | 変更前 | 変更後 | 対応する Renovate PR |
|---|---|---|---|
| `actions/checkout` | v5.1.0 | v7.0.1 | #121 |
| `actions/github-script` | v7 | v9 | #122 |
| `docker/login-action` | v3.7.0 | v4.6.0 | #123 |
| `softprops/action-gh-release` | v2.6.2 | v3.0.2 | #124 |

## なぜ 1 本にまとめるのか

**4 本とも中身は同じ変更**である。いずれの major も「アクションのランタイムを Node 20 から Node 24 へ移す」ことが目的で、そのため **Actions Runner v2.327.1 以降**を要求する。個別に評価しても確認すべき点は同一なので、1 つの変更として扱う。

加えて、このリポジトリでは **workflow だけの変更でもイメージビルド 3 本が走る**（各 25〜37 分）。個別に merge すると rebase のたびにビルドし直しになるため、ビルドサイクルを 1 回で済ませる意味も大きい。

## Node 24 要件の確認

全ジョブが GitHub ホストランナーで動いている。

```
7 × ubuntu-latest
2 × ubuntu-24.04-arm   （arm64 ビルド用）
```

self-hosted ランナーは使っていない。GitHub ホストランナーは v2.327.1 を大きく超えているため、要件は満たされている。

## 入力の互換性

major をまたいでも、呼び出し方は変わっていない。

- `softprops/action-gh-release`: `tag_name` / `name` / `body` を渡す形のまま
- `actions/github-script`: `script` で `github.rest.issues.create` を呼ぶ形のまま
- `actions/checkout` / `docker/login-action`: 引数なし、または既存の `with` のまま

## 検証

`actionlint` の指摘件数が変更前後で同一（12 件）であることを確認した。いずれも `build-pr.yml` の Test ステップにある shellcheck SC2086（info レベル）で、**本 PR とは無関係の既存の指摘**である。

## #117 との関係

グループ PR #117 は CI 実行中に Renovate によって自動マージされた（`619ca5c`）。本 PR はその上に rebase 済みで、#117 が入れた `docker/build-push-action` v7.3.0 / `docker/setup-buildx-action` v4.2.0 / `docker/setup-qemu-action` v4.2.0 と再利用ワークフローの digest はそのまま保っている。重複していた 3 つは #117 が上げた版を起点に major へ進めた（表の「変更前」は rebase 後の値）。

## 後始末

merge 後、#121 / #122 / #123 / #124 は手動で close する。

