### PR TITLE
docs: refresh current version references to 2026d

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ docker build -f alpine/Dockerfile -t texlive-ja-textlint:alpine .
 docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026c --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026d --push .
 ```
 
 ### Test Compilation
@@ -28,8 +28,8 @@ docker run --rm -v $(pwd)/tests:/workspace -w /workspace texlive-ja-textlint:alp
 ### Registry Operations
 ```bash
 # Push to registry (maintainers only)
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026c
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026d
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026d
 ```
 
 ## Image Structure
@@ -46,8 +46,8 @@ docker push ghcr.io/smkwlab/texlive-ja-textlint:2026c
 ## Version Management
 
 ### Current Tags
-- `2026c` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
-- `2026b` - Previous update
+- `2026d` - Latest release at time of writing (also published as `latest`; see README.md for the current list)
+- `2026c` - Previous update
 - Multi-architecture: AMD64, ARM64
 
 ### Version Checking

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Supported tags / タグ一覧
 
 ### 推奨イメージ
-- [`latest`, `2026c`](./debian/Dockerfile)
+- [`latest`, `2026d`](./debian/Dockerfile)
   - お使いの環境に合わせて自動的に最適なイメージを選択
   - Intel Mac/Windows: 軽量・高速版
   - Apple Silicon Mac: 互換性重視版
 
 ### 個別指定イメージ
-- [`alpine`, `2026c-alpine`](./alpine/Dockerfile)
+- [`alpine`, `2026d-alpine`](./alpine/Dockerfile)
   - Intel Mac/Windows専用（軽量・高速）
   - Apple Silicon Macでは動作しません
-- [`debian`, `2026c-debian`](./debian/Dockerfile)
+- [`debian`, `2026d-debian`](./debian/Dockerfile)
   - すべての環境で動作（互換性重視）
 
 ## Install / インストール
@@ -25,9 +25,9 @@ GitHub Container Registry からインストールできます。
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026d
 
-# 最新版（2026cと同じ）
+# 最新版（2026dと同じ）
 docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 ```
 
@@ -35,7 +35,7 @@ docker pull ghcr.io/smkwlab/texlive-ja-textlint:latest
 
 ```bash
 # 推奨: 環境に合わせて自動選択
-$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026c \
+$ docker run --rm -it -v $PWD:/workdir ghcr.io/smkwlab/texlive-ja-textlint:2026d \
     sh -c 'latexmk -C main.tex && latexmk main.tex && latexmk -c main.tex'
 
 # latest タグでも同じ結果

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -29,7 +29,8 @@ that year (`2025`, `2025a`, ..., `2025i`, `2026a`, `2026b`, ...):
 - `2025` - Major TeXLive 2025 release
 - `2025a`-`2025i` - Successive updates during 2025
 - `2026a` - First release of 2026
-- `2026b`-`2026c` - Successive updates during 2026
+- `2026b` - Successive update during 2026
+- `2026c` - Successive update during 2026
 - `2026d` - Current stable release (also published as `latest`)
 
 See [README.md](../README.md) for the tags currently published on the registry.

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -29,8 +29,8 @@ that year (`2025`, `2025a`, ..., `2025i`, `2026a`, `2026b`, ...):
 - `2025` - Major TeXLive 2025 release
 - `2025a`-`2025i` - Successive updates during 2025
 - `2026a` - First release of 2026
-- `2026b` - Successive update during 2026
-- `2026c` - Current stable release (also published as `latest`)
+- `2026b`-`2026c` - Successive updates during 2026
+- `2026d` - Current stable release (also published as `latest`)
 
 See [README.md](../README.md) for the tags currently published on the registry.
 

--- a/docs/CLAUDE-EXAMPLES.md
+++ b/docs/CLAUDE-EXAMPLES.md
@@ -16,7 +16,7 @@ docker build -f debian/Dockerfile -t texlive-ja-textlint:debian .
 docker build -f alpine/Dockerfile -t my-texlive:latest .
 
 # Multi-architecture build
-docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026c --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f alpine/Dockerfile -t ghcr.io/smkwlab/texlive-ja-textlint:2026d --push .
 ```
 
 ### Running Containers
@@ -34,13 +34,13 @@ docker run --rm -v $(pwd)/my-thesis:/workspace -w /workspace texlive-ja-textlint
 ### Registry Operations
 ```bash
 # Tag for registry
-docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker tag texlive-ja-textlint:alpine ghcr.io/smkwlab/texlive-ja-textlint:2026d
 
 # Push to GitHub Container Registry
-docker push ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker push ghcr.io/smkwlab/texlive-ja-textlint:2026d
 
 # Pull from registry
-docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026c
+docker pull ghcr.io/smkwlab/texlive-ja-textlint:2026d
 ```
 
 ## LaTeX Compilation Examples


### PR DESCRIPTION
## 問題

`2026c`（2026-07-30）以降 10 commit が main に溜まっており、配布されていない。CI 設定だけではなく、**イメージの中身が変わる更新**が含まれる。

```
textlint-rule-preset-ja-technical-writing  ^7.0.0  → ^12.0.2
textlint-rule-preset-ja-spacing            ^2.3.0  → ^3.0.2
textlint-rule-no-mix-dearu-desumasu        ^5.0.0  → ^6.0.4
textlint                                   ^15.7.1 → ^15.8.0
textlint-filter-rule-comments              ^1.2.2  → ^1.3.0
node:24-trixie-slim                        @ae91dcc → @ac39e4b
```

学生の文書が何で指摘されるかが変わるため、影響を実測してから配布することにした。

## 影響の実測

新旧のルールセットを実際に構築し、同一の `.textlintrc` で比較した。

### 執筆済みの学生文書には影響なし

draft ブランチから取得した実文書 3 本（日本語 13,236 文字）で、**指摘が行番号・ルール・メッセージまで完全一致**。

```
old  77 件   ja-no-mixed-period:55  sentence-length:11  no-doubled-joshi:4  max-comma:3  max-kanji-continuous-len:4
new  77 件   （同一）
```

学生の文章は既に である調 で書かれているため、後述のルール強化の影響を受けない。

### LaTeX の扱いは改善

`sentence-length` が LaTeX マークアップを本文として数えていたのが直った。

```
\textcircled{\scriptsize 1}の緑色の全範囲がボタンになっており、…に遷移する。
  old: 165 文字と判定 → 指摘        ← \textcircled{} や \ref{} を計上
  new: 判定対象外                    ← 実際の文章長で判定
```

誤検知が 1 件消え、別の箇所も 138 → 118 文字と実態に近づいた。

### 事前に潰した問題

`no-mix-dearu-desumasu` v6 は、v5 が見逃していた `preferInBody: "である"` 違反を検出するようになる。`latex-template` の見本が全編 ですます調 だったため、そのままでは新規リポジトリの学生が 1 文字も書く前に 11 件の指摘を受ける状態だった。

見本を である調 に書き換え済み（smkwlab/latex-template#57、merge 済み）。sotsuron / ise のテンプレートは元から である調 で、新ルールでも 0 件。

## 対応

タグを切る前に、文書中のバージョン参照を `2026d` に更新する。2026c の際と同じ手順（タグが捉える tree が既に正しい状態になるようにする）。

## 次の手順

1. この PR を merge
2. その commit に `2026d` タグを打つ → `build-tag.yml` がイメージを publish
3. 消費者を `2026d` へ揃える（latex-environment の devcontainer は現在 2026c、latex-release-action の Dockerfile は 2026a で 2 世代遅れ）
