### PR TITLE
ci: only ask for a README update when one is missing

### DIFF
--- a/.github/workflows/update-readme-issue.yml
+++ b/.github/workflows/update-readme-issue.yml
@@ -44,7 +44,9 @@ jobs:
         run: |
           # 出現の有無だけを見る。どの節が更新済みかまでは踏み込まない。
           # 手順を踏み忘れたときに気付ければ足りる。
-          if grep -q "$TAG" README.md; then
+          # -F はタグ名をリテラルとして扱うため。現在の命名（2026d 等）に
+          # 正規表現のメタ文字は入らないが、入った時に黙って誤判定させない。
+          if grep -qF "$TAG" README.md; then
             echo "::notice::README.md already names ${TAG}; nothing to file"
             echo "needed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/update-readme-issue.yml
+++ b/.github/workflows/update-readme-issue.yml
@@ -1,4 +1,12 @@
 ---
+# リリース後、README がまだ新しいタグを名乗っていなければ更新用の issue を立てる。
+#
+# 起票を条件付きにしているのは、リリース手順が「ドキュメント更新 → タグ push」の
+# 順だから（タグが捉えるツリーの時点で記述が正しくなるようにするため）。無条件に
+# 起票すると、常に充足済みのチェックリストが毎回立つ。実際 2026a / 2026b / 2026d
+# の 3 回とも no-op で、うち 1 件は約 2 か月 open のまま放置された（#29、#131）。
+#
+# 手順を踏み忘れた場合の安全網としては残す。
 name: Create README Update Issue
 on:
   workflow_run:
@@ -11,6 +19,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Extract tag name
@@ -21,7 +30,29 @@ jobs:
           TAG_NAME="${TAG_NAME#refs/tags/}"
           echo "name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
+      # 既定のブランチではなくタグを見る。判断したいのは「このリリースが配る
+      # ツリーの README が正しいか」であって、その後 main がどうなったかではない。
+      - name: Checkout the released tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: Check whether the README already names the tag
+        id: check
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          # 出現の有無だけを見る。どの節が更新済みかまでは踏み込まない。
+          # 手順を踏み忘れたときに気付ければ足りる。
+          if grep -q "$TAG" README.md; then
+            echo "::notice::README.md already names ${TAG}; nothing to file"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Issue
+        if: steps.check.outputs.needed == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |


### PR DESCRIPTION
Refs #29

## 問題

`update-readme-issue.yml` は `Build tag` の成功後に無条件で README 更新の issue を立てるが、**リリース手順が「ドキュメント更新 → タグ push」の順**であるため、起票された時点でチェックリストが常に充足済みになる。

この順序自体は妥当である。タグが捉えるツリーの時点で記述が正しくなるようにするためで、意図して選んでいる。

結果として no-op が積み上がっている。

```
#73  (2026a) — 実作業あり(#74/#92)。ただし約 2 か月 open のまま放置
#103 (2026b) — 4 項目すべて充足済み、同日 close
     (2026c) — 同じく no-op
#131 (2026d) — 同じく no-op
```

問題は無駄な issue が立つことだけではない。**本物と区別が付かなくなる**。#73 は実際に作業が必要だったが、no-op と同じ見た目だったために 2 か月放置された。

## 対応

#29 で選ばれた案（「ドキュメント先行を正とし、自動起票を条件付きにする」）を実装する。タグをチェックアウトし、その README が当該タグを名乗っていなければ起票する。

```yaml
      - name: Checkout the released tag
        uses: actions/checkout@3d3c42e5… # v7.0.1
        with:
          ref: ${{ steps.tag.outputs.name }}

      - name: Check whether the README already names the tag
        id: check
        env:
          TAG: ${{ steps.tag.outputs.name }}
        run: |
          if grep -q "$TAG" README.md; then
            echo "::notice::README.md already names ${TAG}; nothing to file"
            echo "needed=false" >> "$GITHUB_OUTPUT"
          else
            echo "needed=true" >> "$GITHUB_OUTPUT"
          fi
```

既定ブランチではなくタグを見るのは、判断したいのが「このリリースが配るツリーの README が正しいか」であって、その後 main がどうなったかではないため。

判定は出現の有無だけで、どの節が更新済みかまでは踏み込まない。手順を踏み忘れたときに気付ければ足りる（#29 でもこの粒度で妥当とされている）。あわせて checkout のため `contents: read` を追加した。

## 検証

2026 年の全リリースに対して判定を実行し、実績と突き合わせた。

| タグ | 判定 | 実績 |
|---|---|---|
| 2026a | **needed=true（起票する）** | #73 起票 → 実作業あり |
| 2026b | needed=false | #103 → no-op |
| 2026c | needed=false | no-op |
| 2026d | needed=false | #131 → no-op |

**作業が必要だった 1 件だけが起票され、no-op 3 件は抑止される。** 安全網としての機能は保たれている。

`actionlint` は指摘なし。

## 本 issue との関係

`Resolves` は付けていない。#29 はエコシステム全体への拡張という広い主題で、2025-11-06 に「自動化は見送り手動運用を維持する」と判断されたうえで参照用に open のまま残されている。本 PR はそこに追記された既存ワークフローの整理に対応するもので、#29 の主題を解決するものではない。

#131（今回の no-op 実例）は、チェックリスト 4 項目が充足済みであることを確認したうえで close 済み。
