### PR TITLE
ci: drop the QEMU setup left from the native runner move

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -18,11 +18,14 @@ inputs:
   tags:
     description: List of tags
     required: true
+# Each caller builds a single platform on a runner of that architecture
+# (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm), so no emulation is
+# involved. Multi-arch tags are assembled afterwards by `docker buildx
+# imagetools create` in the create-manifests job. Building several platforms
+# in one job would need docker/setup-qemu-action here.
 runs:
   using: 'composite'
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       with:


### PR DESCRIPTION
## 背景

`.github/actions/build/action.yml` が全ビルドで `setup-qemu-action` を実行していたが、この composite action を呼ぶ 3 ジョブはいずれも **runner 自身のアーキテクチャ単体**をビルドしている。multi-arch はビルド時ではなく `create-manifests` ジョブの `docker buildx imagetools create` で既存イメージを統合して作っており、クロスアーキテクチャのバイナリを実行する場面が無い。native ARM runner へ移行した際の残滓である。

実害は時間（総所要の 0.3〜0.6%）ではなく、**構成を誤読させること**にある。これが残っていると「ARM64 はエミュレーションでビルドしている」と読めてしまい、ビルドが 30 分以上かかる理由（実際は TeX Live のインストール）についても的外れな改善提案に至る余地がある。

## 変更内容

- `setup-qemu-action` のステップを削除する
- この composite action が「1 ジョブ 1 アーキテクチャ・native ビルド」を前提にしていることをコメントで明示する。将来 1 ジョブで複数アーキテクチャを同時にビルドする構成にする場合は QEMU が必要になる旨も含める

`qemu` / `binfmt` への参照はこの 1 箇所だけだった。

## 検証

**この PR 自体が実地検証になる。** `build-pr.yml` の `shared` フィルタに `.github/actions/build/**` が含まれるため、この変更は 3 ビルドジョブすべてを起動する。

| ジョブ | runs-on | platforms | 検証内容 |
|---|---|---|---|
| `build-alpine` | `ubuntu-latest` | 既定（amd64） | ビルド後に `docker run` で textlint + latexmk |
| `build-debian` | `ubuntu-latest` | `linux/amd64` | 同上 |
| `build-debian-arm64` | `ubuntu-24.04-arm` | `linux/arm64` | 同上 |

いずれも `load: true` でビルドしたイメージを同じ runner 上で実行するため native 実行であり、**arm64 ジョブが QEMU 無しで通ることが、binfmt 登録が結果に影響していなかったことの直接の証拠**になる。

タグを切ったうえでの `docker buildx imagetools inspect`（amd64 / arm64 両方が manifest に含まれること）は、次のイメージ発行時に確認する。`create-manifests` は既存イメージを統合するだけで QEMU に依存しないため、この変更の影響を受けない。

なお `yamllint` / `actionlint` の既存の指摘（行長・SC2086）はこの変更とは無関係で、増やしていない。

Resolves #130