### PR TITLE
chore(renovate): inherit lock file maintenance from the shared preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>smkwlab/.github:latex#v1"],
-  "lockFileMaintenance": {
-    "description": "The latex preset bumps direct npm dependencies but never refreshes the lock file, so advisories in transitive packages accumulate unseen. Regenerate the lock files on the same weekly cadence as the preset's other updates.",
-    "enabled": true,
-    "schedule": ["after 9pm on sunday"]
-  }
+  "extends": ["github>smkwlab/.github:latex#v1"]
 }


### PR DESCRIPTION
## 背景

このリポジトリは `lockFileMaintenance` をローカルで有効化していた。理由は「直接依存だけ上げても推移的パッケージの advisory が見えないまま溜まる」というもので、その判断は smkwlab/.github#133 で共有 preset（`:latex`）側の既定になり、v1.33.0 で配布済みである。

同じ設定が 2 箇所にあると、片方だけ直したときに黙ってずれる。ローカル定義を落として preset に一本化する。

## 変更内容

`.github/renovate.json` から `lockFileMaintenance` ブロックを削除する。残るのは `extends` のみ。

## 挙動が変わらないことの確認

削除後に preset から継承される値が、削除するローカル値と一致することを実物で確認した。

```
$ gh api repos/smkwlab/.github/contents/latex.json?ref=v1 --jq .content | base64 -d | jq .lockFileMaintenance
{ "enabled": true, "schedule": ["after 9pm on sunday"] }

$ git show HEAD:.github/renovate.json | jq '.lockFileMaintenance | {enabled, schedule}'
{ "enabled": true, "schedule": ["after 9pm on sunday"] }
```

`renovate-config-validator` も通っている。

ローカル定義に書いていた理由（推移的依存の advisory が溜まる）は preset 側の `description` に移してあるので、経緯は失われない。
