### PR TITLE
ci: return the shared workflow reference to the moving tag

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   review:
-    uses: smkwlab/.github/.github/workflows/ai-review.yml@ad3357f893e39d13f7efc358248e839ca20679a2 # v1
+    uses: smkwlab/.github/.github/workflows/ai-review.yml@v1
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## 背景

`smkwlab/.github` の共有ワークフローへの参照が digest 固定されており、エコシステム全体で 3 通りに割れていた（smkwlab/latex-ecosystem#169）。固定は意図した選択ではなく、`:latex` preset の `pinDigests: true` が Renovate 実行のたびに書き換えていた結果である。

固定の根拠は「Renovate が居る側は固定する。変更のたびにレビューの機会が生じる」だが、共有ワークフローでは成立しない。**`v1` の付け替えは学生リポジトリに先に届き**、このリポジトリの digest を Renovate が上げるのはその後になる。固定は「最初に気付く」ではなく「最後に気付く」を意味していた。

## 変更内容

`ai-review.yml` への参照を移動タグに戻す。

```yaml
uses: smkwlab/.github/.github/workflows/ai-review.yml@v1
```

preset 側のガード（`smkwlab/.github` の `pinDigests: false`）は smkwlab/.github#136 で入れ、v1.36.0 で配布済み。**この PR より先に配布を済ませてある**ので、次の Renovate 実行で再び固定されることはない。

## 検証

マージ後、次回の Renovate 実行で参照が `@v1` のまま保たれることを確認する。固定され直した場合は preset のガードが効いていない証拠になる。

ref: smkwlab/latex-ecosystem#169